### PR TITLE
Combined dependency updates (2022-12-04)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       packages: write 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3.0.2
+      - uses: actions/setup-dotnet@v3.0.3
         with:
             dotnet-version: '3.1.x'
       - name: Pack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       #https://stackoverflow.com/questions/61096521/how-to-use-gpg-key-in-github-actions
       #It requires export the private key with the armor option: gpg --output private.pgm --armor --export-secret-key <email>
       - name: Import GPG Key 
-        uses: crazy-max/ghaction-import-gpg@v5.1.0
+        uses: crazy-max/ghaction-import-gpg@v5.2.0
         with:
           gpg_private_key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: '8'
           cache: 'maven'
       - if: ${{ matrix.platform=='net' }}
-        uses: actions/setup-dotnet@v3.0.2
+        uses: actions/setup-dotnet@v3.0.3
         with:
             dotnet-version: '3.1.x'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
       #    skip_publishing: ${{ github.actor != 'javiertuya' }} #avoids failure on dependabot or other user PRs
       - name: Generate report checks1
         if: always()
-        uses: mikepenz/action-junit-report@v3.5.1
+        uses: mikepenz/action-junit-report@v3.6.1
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -85,7 +85,7 @@
 		<dependency>
     		<groupId>io.github.bonigarcia</groupId>
     		<artifactId>webdrivermanager</artifactId>
-    		<version>5.3.0</version>
+    		<version>5.3.1</version>
 		</dependency>
 
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -97,7 +97,7 @@
 		<dependency>
 		    <groupId>org.slf4j</groupId>
 		    <artifactId>slf4j-api</artifactId>
-		    <version>2.0.3</version>
+		    <version>2.0.5</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -67,7 +67,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.5.0</version>
+			<version>4.7.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<!-- selenium 3

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -52,7 +52,7 @@
     <PackageReference Include="NLog" Version="4.7.15" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="VisualAssert" Version="2.2.1" />
-    <PackageReference Include="WebDriverManager" Version="2.16.0" />
+    <PackageReference Include="WebDriverManager" Version="2.16.1" />
     <!--
     <PackageReference Include="Selenium.WebDriver" Version="4.1.0" />
     -->

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
     <!--
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
     -->

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="NUnit" Version="3.13.3" />


### PR DESCRIPTION
Includes these updates:
- [Bump actions/setup-dotnet from 3.0.2 to 3.0.3](https://github.com/javiertuya/selema/pull/124)
- [Bump crazy-max/ghaction-import-gpg from 5.1.0 to 5.2.0](https://github.com/javiertuya/selema/pull/121)
- [Bump mikepenz/action-junit-report from 3.5.1 to 3.6.1](https://github.com/javiertuya/selema/pull/133)
- [Bump webdrivermanager from 5.3.0 to 5.3.1 in /java](https://github.com/javiertuya/selema/pull/127)
- [Bump selenium-java from 4.5.0 to 4.7.0 in /java](https://github.com/javiertuya/selema/pull/135)
- [Bump slf4j-api from 2.0.3 to 2.0.5 in /java](https://github.com/javiertuya/selema/pull/134)
- [Bump Microsoft.NET.Test.Sdk from 17.3.2 to 17.4.0 in /net](https://github.com/javiertuya/selema/pull/129)
- [Bump NUnit3TestAdapter from 4.2.1 to 4.3.1 in /net](https://github.com/javiertuya/selema/pull/132)
- [Bump WebDriverManager from 2.16.0 to 2.16.1 in /net](https://github.com/javiertuya/selema/pull/130)