### PR TITLE
Combined dependency updates (2022-12-17)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
       #    skip_publishing: ${{ github.actor != 'javiertuya' }} #avoids failure on dependabot or other user PRs
       - name: Generate report checks1
         if: always()
-        uses: mikepenz/action-junit-report@v3.6.1
+        uses: mikepenz/action-junit-report@v3.7.0
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -97,7 +97,7 @@
 		<dependency>
 		    <groupId>org.slf4j</groupId>
 		    <artifactId>slf4j-api</artifactId>
-		    <version>2.0.5</version>
+		    <version>2.0.6</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -67,7 +67,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.7.0</version>
+			<version>4.7.2</version>
 			<scope>provided</scope>
 		</dependency>
 		<!-- selenium 3

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -56,7 +56,7 @@
     <!--
     <PackageReference Include="Selenium.WebDriver" Version="4.1.0" />
     -->
-    <PackageReference Include="Selenium.WebDriver" Version="4.5.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.7.0" />
   </ItemGroup>
 
 </Project>

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -17,7 +17,7 @@
     <!--
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
     -->
-    <PackageReference Include="Selenium.WebDriver" Version="4.5.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 3.6.1 to 3.7.0](https://github.com/javiertuya/selema/pull/145)
- [Bump selenium-java from 4.7.0 to 4.7.2 in /java](https://github.com/javiertuya/selema/pull/144)
- [Bump slf4j-api from 2.0.5 to 2.0.6 in /java](https://github.com/javiertuya/selema/pull/143)
- [Bump Microsoft.NET.Test.Sdk from 17.4.0 to 17.4.1 in /net](https://github.com/javiertuya/selema/pull/146)
- [Bump Selenium.WebDriver from 4.5.1 to 4.7.0 in /net](https://github.com/javiertuya/selema/pull/136)