### PR TITLE
Combined dependency updates (2022-12-21)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -74,7 +74,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>visual-assert</artifactId>
-			<version>2.2.1</version>
+			<version>2.2.2</version>
 		</dependency>
 
 		<dependency>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -56,7 +56,7 @@
 
     <PackageReference Include="NUnit" Version="3.13.3" />
 
-    <PackageReference Include="VisualAssert" Version="2.2.1" />
+    <PackageReference Include="VisualAssert" Version="2.2.2" />
 
     <PackageReference Include="WebDriverManager" Version="2.16.2" />
     <!--

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.3.0</version>
+			<version>4.7.2</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.1" />
 

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.1" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.1" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.7.0" />
     

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.1" />
 
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
 

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.13.3" />
 
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
 

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.7.0" />
 


### PR DESCRIPTION
Includes these updates:
- [Bump visual-assert from 2.2.1 to 2.2.2 in /java](https://github.com/javiertuya/selema/pull/152)
- [Bump selenium-java from 4.3.0 to 4.7.2 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/150)
- [Bump VisualAssert from 2.2.1 to 2.2.2 in /net](https://github.com/javiertuya/selema/pull/149)
- [Bump MSTest.TestAdapter from 2.2.10 to 3.0.1 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/154)
- [Bump MSTest.TestFramework from 2.2.10 to 3.0.1 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/155)
- [Bump Microsoft.NET.Test.Sdk from 17.2.0 to 17.4.1 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/151)
- [Bump Microsoft.NET.Test.Sdk from 17.2.0 to 17.4.1 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/148)
- [Bump NUnit3TestAdapter from 4.2.1 to 4.3.1 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/153)