### PR TITLE
Combined dependency updates (2022-12-22)

### DIFF
--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.0.0</version>
+			<version>3.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.3.0</version>
+			<version>4.7.2</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.8.2</version>
+			<version>5.9.1</version>
 		</dependency>
 		<dependency>
 		   <groupId>io.github.artsok</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.0.0</version>
+			<version>3.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -16,7 +16,7 @@
 
     <PackageReference Include="Selenium.WebDriver" Version="4.7.0" />
     
-    <PackageReference Include="Selema" Version="3.0.0" />
+    <PackageReference Include="Selema" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -16,7 +16,7 @@
 
     <PackageReference Include="Selenium.WebDriver" Version="4.7.0" />
 
-    <PackageReference Include="Selema" Version="3.0.0" />
+    <PackageReference Include="Selema" Version="3.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Includes these updates:
- [Bump selema from 3.0.0 to 3.0.1 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/157)
- [Bump selema from 3.0.0 to 3.0.1 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/161)
- [Bump junit-jupiter-engine from 5.8.2 to 5.9.1 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/160)
- [Bump selenium-java from 4.3.0 to 4.7.2 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/162)
- [Bump Selema from 3.0.0 to 3.0.1 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/159)
- [Bump Selema from 3.0.0 to 3.0.1 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/158)