### PR TITLE
Combined dependency updates (2023-01-02)

### DIFF
--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.7.0" />
     

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
 
     <PackageReference Include="MSTest.TestFramework" Version="3.0.1" />
 


### PR DESCRIPTION
Includes these updates:
- [Bump MSTest.TestAdapter from 3.0.1 to 3.0.2 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/164)
- [Bump MSTest.TestFramework from 3.0.1 to 3.0.2 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/165)