### PR TITLE
Combined dependency updates (2023-01-14)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
       #    skip_publishing: ${{ github.actor != 'javiertuya' }} #avoids failure on dependabot or other user PRs
       - name: Generate report checks1
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.0
+        uses: mikepenz/action-junit-report@v3.7.1
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 
-		<junit-jupiter.version>5.9.1</junit-jupiter.version>
+		<junit-jupiter.version>5.9.2</junit-jupiter.version>
 
 		<junit.version>4.13.2</junit.version>
 		

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -201,7 +201,7 @@
 					<dependency>
 						<groupId>org.apache.ant</groupId>
 						<artifactId>ant-junit</artifactId>
-						<version>1.10.12</version>
+						<version>1.10.13</version>
 					</dependency>
 					<dependency>
 						<groupId>org.apache.ant</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.9.1</version>
+			<version>5.9.2</version>
 		</dependency>
 		<dependency>
 		   <groupId>io.github.artsok</groupId>


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 3.7.0 to 3.7.1](https://github.com/javiertuya/selema/pull/167)
- [Bump junit-jupiter.version from 5.9.1 to 5.9.2 in /java](https://github.com/javiertuya/selema/pull/168)
- [Bump ant-junit from 1.10.12 to 1.10.13 in /java](https://github.com/javiertuya/selema/pull/169)
- [Bump junit-jupiter-engine from 5.9.1 to 5.9.2 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/170)