### PR TITLE
Combined dependency updates (2023-01-26)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -68,7 +68,7 @@
 		<dependency>
 			<groupId>io.github.bonigarcia</groupId>
 			<artifactId>webdrivermanager</artifactId>
-			<version>5.3.1</version>
+			<version>5.3.2</version>
 		</dependency>
 
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -62,7 +62,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.7.2</version>
+			<version>4.8.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -62,7 +62,7 @@
     <!--
     <PackageReference Include="Selenium.WebDriver" Version="4.1.0" />
     -->
-    <PackageReference Include="Selenium.WebDriver" Version="4.7.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.8.0" />
   </ItemGroup>
 
 </Project>

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -17,7 +17,7 @@
     <!--
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
     -->
-    <PackageReference Include="Selenium.WebDriver" Version="4.7.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.7.2</version>
+			<version>4.8.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.7.2</version>
+			<version>4.8.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.7.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.8.0" />
     
     <PackageReference Include="Selema" Version="3.0.1" />
   </ItemGroup>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.7.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.8.0" />
 
     <PackageReference Include="Selema" Version="3.0.1" />
   </ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Bump webdrivermanager from 5.3.1 to 5.3.2 in /java](https://github.com/javiertuya/selema/pull/172)
- [Bump selenium-java from 4.7.2 to 4.8.0 in /java](https://github.com/javiertuya/selema/pull/173)
- [Bump selenium-java from 4.7.2 to 4.8.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/175)
- [Bump selenium-java from 4.7.2 to 4.8.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/177)
- [Bump Selenium.WebDriver from 4.7.0 to 4.8.0 in /net](https://github.com/javiertuya/selema/pull/174)
- [Bump Selenium.WebDriver from 4.7.0 to 4.8.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/176)
- [Bump Selenium.WebDriver from 4.7.0 to 4.8.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/178)