### PR TITLE
Combined dependency updates (2023-02-25)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
       #    skip_publishing: ${{ github.actor != 'javiertuya' }} #avoids failure on dependabot or other user PRs
       - name: Generate report checks1
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.3
+        uses: mikepenz/action-junit-report@v3.7.5
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -62,7 +62,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.8.0</version>
+			<version>4.8.1</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -62,7 +62,7 @@
     <!--
     <PackageReference Include="Selenium.WebDriver" Version="4.1.0" />
     -->
-    <PackageReference Include="Selenium.WebDriver" Version="4.8.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.8.1" />
   </ItemGroup>
 
 </Project>

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -17,7 +17,7 @@
     <!--
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
     -->
-    <PackageReference Include="Selenium.WebDriver" Version="4.8.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.8.0</version>
+			<version>4.8.1</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.8.0</version>
+			<version>4.8.1</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
 

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.8.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.8.1" />
     
     <PackageReference Include="Selema" Version="3.0.1" />
   </ItemGroup>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.8.0" />
 

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.8.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.8.1" />
 
     <PackageReference Include="Selema" Version="3.0.1" />
   </ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 3.7.3 to 3.7.5](https://github.com/javiertuya/selema/pull/192)
- [Bump selenium-java from 4.8.0 to 4.8.1 in /java](https://github.com/javiertuya/selema/pull/185)
- [Bump selenium-java from 4.8.0 to 4.8.1 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/188)
- [Bump selenium-java from 4.8.0 to 4.8.1 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/187)
- [Bump Microsoft.NET.Test.Sdk from 17.4.1 to 17.5.0 in /net](https://github.com/javiertuya/selema/pull/191)
- [Bump Selenium.WebDriver from 4.8.0 to 4.8.1 in /net](https://github.com/javiertuya/selema/pull/186)
- [Bump Microsoft.NET.Test.Sdk from 17.4.1 to 17.5.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/193)
- [Bump Selenium.WebDriver from 4.8.0 to 4.8.1 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/189)
- [Bump Microsoft.NET.Test.Sdk from 17.4.1 to 17.5.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/194)
- [Bump Selenium.WebDriver from 4.8.0 to 4.8.1 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/190)