### PR TITLE
Combined dependency updates (2023-03-04)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -101,7 +101,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.10.1</version>
+				<version>3.11.0</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <!--
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
     -->

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.13.3" />
 
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
 


### PR DESCRIPTION
Includes these updates:
- [Bump maven-compiler-plugin from 3.10.1 to 3.11.0 in /java](https://github.com/javiertuya/selema/pull/198)
- [Bump NUnit3TestAdapter from 4.3.1 to 4.4.2 in /net](https://github.com/javiertuya/selema/pull/199)
- [Bump NUnit3TestAdapter from 4.3.1 to 4.4.2 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/200)