### PR TITLE
Combined dependency updates (2023-03-18)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -110,7 +110,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.2</version>
+				<version>3.0.0</version>
 				<configuration>
 					<testFailureIgnore>true</testFailureIgnore>
 					<!-- Sets the VM argument line used when unit tests are run under JaCoCo -->

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -157,7 +157,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>2.22.2</version>
+				<version>3.0.0</version>
 				<executions>
 					<execution>
 						<id>ut-reports</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -74,7 +74,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>visual-assert</artifactId>
-			<version>2.2.2</version>
+			<version>2.3.0</version>
 		</dependency>
 
 		<dependency>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -47,7 +47,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.2</version>
+				<version>3.0.0</version>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Includes these updates:
- [Bump visual-assert from 2.2.2 to 2.3.0 in /java](https://github.com/javiertuya/selema/pull/202)
- [Bump maven-surefire-plugin from 2.22.2 to 3.0.0 in /java](https://github.com/javiertuya/selema/pull/204)
- [Bump maven-surefire-report-plugin from 2.22.2 to 3.0.0 in /java](https://github.com/javiertuya/selema/pull/205)
- [Bump maven-surefire-plugin from 2.22.2 to 3.0.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/203)