### PR TITLE
Combined dependency updates (2023-04-02)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -25,7 +25,7 @@
 
 		<junit.version>4.13.2</junit.version>
 		
-		<slf4j.version>2.0.6</slf4j.version>
+		<slf4j.version>2.0.7</slf4j.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -62,7 +62,7 @@
     <!--
     <PackageReference Include="Selenium.WebDriver" Version="4.1.0" />
     -->
-    <PackageReference Include="Selenium.WebDriver" Version="4.8.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.8.2" />
   </ItemGroup>
 
 </Project>

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -17,7 +17,7 @@
     <!--
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
     -->
-    <PackageReference Include="Selenium.WebDriver" Version="4.8.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.8.1</version>
+			<version>4.8.3</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.8.1</version>
+			<version>4.8.3</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.8.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.8.2" />
     
     <PackageReference Include="Selema" Version="3.0.1" />
   </ItemGroup>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.8.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.8.2" />
 
     <PackageReference Include="Selema" Version="3.0.1" />
   </ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Bump slf4j.version from 2.0.6 to 2.0.7 in /java](https://github.com/javiertuya/selema/pull/209)
- [Bump selenium-java from 4.8.1 to 4.8.3 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/214)
- [Bump selenium-java from 4.8.1 to 4.8.3 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/213)
- [Bump Selenium.WebDriver from 4.8.1 to 4.8.2 in /net](https://github.com/javiertuya/selema/pull/211)
- [Bump Selenium.WebDriver from 4.8.1 to 4.8.2 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/215)
- [Bump Selenium.WebDriver from 4.8.1 to 4.8.2 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/212)