### PR TITLE
Combined dependency updates (2023-04-11)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
       #    skip_publishing: ${{ github.actor != 'javiertuya' }} #avoids failure on dependabot or other user PRs
       - name: Generate report checks1
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.5
+        uses: mikepenz/action-junit-report@v3.7.6
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -134,7 +134,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.9</version>
 				<executions>
 					<execution>
 						<id>pre-unit-test</id>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -52,7 +52,7 @@
 
     <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
 
-    <PackageReference Include="NLog" Version="5.1.2" />
+    <PackageReference Include="NLog" Version="5.1.3" />
 
     <PackageReference Include="NUnit" Version="3.13.3" />
 

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.0.1</version>
+			<version>3.0.2</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.0.1</version>
+			<version>3.0.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -16,7 +16,7 @@
 
     <PackageReference Include="Selenium.WebDriver" Version="4.8.2" />
     
-    <PackageReference Include="Selema" Version="3.0.1" />
+    <PackageReference Include="Selema" Version="3.0.2" />
   </ItemGroup>
 
 </Project>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -16,7 +16,7 @@
 
     <PackageReference Include="Selenium.WebDriver" Version="4.8.2" />
 
-    <PackageReference Include="Selema" Version="3.0.1" />
+    <PackageReference Include="Selema" Version="3.0.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 3.7.5 to 3.7.6](https://github.com/javiertuya/selema/pull/217)
- [Bump jacoco-maven-plugin from 0.8.8 to 0.8.9 in /java](https://github.com/javiertuya/selema/pull/223)
- [Bump selema from 3.0.1 to 3.0.2 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/218)
- [Bump selema from 3.0.1 to 3.0.2 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/220)
- [Bump NLog from 5.1.2 to 5.1.3 in /net](https://github.com/javiertuya/selema/pull/221)
- [Bump Selema from 3.0.1 to 3.0.2 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/219)
- [Bump Selema from 3.0.1 to 3.0.2 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/222)