### PR TITLE
Combined dependency updates (2023-04-23)

### DIFF
--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -64,7 +64,7 @@
     <!--
     <PackageReference Include="Selenium.WebDriver" Version="4.1.0" />
     -->
-    <PackageReference Include="Selenium.WebDriver" Version="4.8.2" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.9.0" />
   </ItemGroup>
 
 </Project>

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>    
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
@@ -17,7 +17,7 @@
     <!--
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
     -->
-    <PackageReference Include="Selenium.WebDriver" Version="4.8.2" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.8.3</version>
+			<version>4.9.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.8.3</version>
+			<version>4.9.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.8.2" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.9.0" />
     
     <PackageReference Include="Selema" Version="3.0.2" />
   </ItemGroup>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.8.2" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.9.0" />
 
     <PackageReference Include="Selema" Version="3.0.2" />
   </ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Bump selenium-java from 4.8.3 to 4.9.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/227)
- [Bump selenium-java from 4.8.3 to 4.9.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/228)
- [Bump Selenium.WebDriver from 4.8.2 to 4.9.0 in /net](https://github.com/javiertuya/selema/pull/226)
- [Bump Selenium.WebDriver from 4.8.2 to 4.9.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/229)
- [Bump Selenium.WebDriver from 4.8.2 to 4.9.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/230)