### PR TITLE
Combined dependency updates (2023-05-01)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 
-		<junit-jupiter.version>5.9.2</junit-jupiter.version>
+		<junit-jupiter.version>5.9.3</junit-jupiter.version>
 
 		<junit.version>4.13.2</junit.version>
 		

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -134,7 +134,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.9</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<id>pre-unit-test</id>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -52,7 +52,7 @@
 
     <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
 
-    <PackageReference Include="NLog" Version="5.1.3" />
+    <PackageReference Include="NLog" Version="5.1.4" />
 
     <PackageReference Include="NUnit" Version="3.13.3" />
 

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.0.2</version>
+			<version>3.0.3</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.9.2</version>
+			<version>5.9.3</version>
 		</dependency>
 		<dependency>
 		   <groupId>io.github.artsok</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.0.2</version>
+			<version>3.0.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -16,7 +16,7 @@
 
     <PackageReference Include="Selenium.WebDriver" Version="4.9.0" />
     
-    <PackageReference Include="Selema" Version="3.0.2" />
+    <PackageReference Include="Selema" Version="3.0.3" />
   </ItemGroup>
 
 </Project>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -16,7 +16,7 @@
 
     <PackageReference Include="Selenium.WebDriver" Version="4.9.0" />
 
-    <PackageReference Include="Selema" Version="3.0.2" />
+    <PackageReference Include="Selema" Version="3.0.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Includes these updates:
- [Bump junit-jupiter.version from 5.9.2 to 5.9.3 in /java](https://github.com/javiertuya/selema/pull/240)
- [Bump jacoco-maven-plugin from 0.8.9 to 0.8.10 in /java](https://github.com/javiertuya/selema/pull/239)
- [Bump selema from 3.0.2 to 3.0.3 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/235)
- [Bump selema from 3.0.2 to 3.0.3 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/238)
- [Bump junit-jupiter-engine from 5.9.2 to 5.9.3 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/241)
- [Bump NLog from 5.1.3 to 5.1.4 in /net](https://github.com/javiertuya/selema/pull/242)
- [Bump Selema from 3.0.2 to 3.0.3 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/237)
- [Bump Selema from 3.0.2 to 3.0.3 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/236)