### PR TITLE
Combined dependency updates (2023-05-12)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       #https://stackoverflow.com/questions/61096521/how-to-use-gpg-key-in-github-actions
       #It requires export the private key with the armor option: gpg --output private.pgm --armor --export-secret-key <email>
       - name: Import GPG Key 
-        uses: crazy-max/ghaction-import-gpg@v5.2.0
+        uses: crazy-max/ghaction-import-gpg@v5.3.0
         with:
           gpg_private_key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -115,7 +115,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.1.0</version>
 				<configuration>
 					<testFailureIgnore>true</testFailureIgnore>
 					<!-- Sets the VM argument line used when unit tests are run under JaCoCo -->

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -68,7 +68,7 @@
 		<dependency>
 			<groupId>io.github.bonigarcia</groupId>
 			<artifactId>webdrivermanager</artifactId>
-			<version>5.3.2</version>
+			<version>5.3.3</version>
 		</dependency>
 
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -62,7 +62,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.9.0</version>
+			<version>4.9.1</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -162,7 +162,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<id>ut-reports</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -74,7 +74,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>portable-java</artifactId>
-			<version>2.1.3</version>
+			<version>2.2.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -259,7 +259,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>
-				<version>3.0.1</version>
+				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<id>sign-artifacts</id>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -62,7 +62,7 @@
 
     <PackageReference Include="WebDriverManager" Version="2.16.2" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.9.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.9.1" />
   </ItemGroup>
 
 </Project>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -56,7 +56,7 @@
 
     <PackageReference Include="NUnit" Version="3.13.3" />
 
-    <PackageReference Include="PortableCs" Version="2.1.3" />
+    <PackageReference Include="PortableCs" Version="2.2.0" />
 
     <PackageReference Include="VisualAssert" Version="2.2.2" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>    
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
@@ -14,7 +14,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.9.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.9.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.9.0</version>
+			<version>4.9.1</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.9.0</version>
+			<version>4.9.1</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -47,7 +47,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.1.0</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.9.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.9.1" />
     
     <PackageReference Include="Selema" Version="3.0.3" />
   </ItemGroup>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.9.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.9.1" />
 
     <PackageReference Include="Selema" Version="3.0.3" />
   </ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Bump crazy-max/ghaction-import-gpg from 5.2.0 to 5.3.0](https://github.com/javiertuya/selema/pull/246)
- [Bump webdrivermanager from 5.3.2 to 5.3.3 in /java](https://github.com/javiertuya/selema/pull/257)
- [Bump portable-java from 2.1.3 to 2.2.0 in /java](https://github.com/javiertuya/selema/pull/244)
- [Bump maven-gpg-plugin from 3.0.1 to 3.1.0 in /java](https://github.com/javiertuya/selema/pull/248)
- [Bump maven-surefire-plugin from 3.0.0 to 3.1.0 in /java](https://github.com/javiertuya/selema/pull/247)
- [Bump maven-surefire-report-plugin from 3.0.0 to 3.1.0 in /java](https://github.com/javiertuya/selema/pull/249)
- [Bump selenium-java from 4.9.0 to 4.9.1 in /java](https://github.com/javiertuya/selema/pull/251)
- [Bump selenium-java from 4.9.0 to 4.9.1 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/254)
- [Bump maven-surefire-plugin from 3.0.0 to 3.1.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/250)
- [Bump selenium-java from 4.9.0 to 4.9.1 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/256)
- [Bump PortableCs from 2.1.3 to 2.2.0 in /net](https://github.com/javiertuya/selema/pull/245)
- [Bump Selenium.WebDriver from 4.9.0 to 4.9.1 in /net](https://github.com/javiertuya/selema/pull/252)
- [Bump Selenium.WebDriver from 4.9.0 to 4.9.1 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/253)
- [Bump Selenium.WebDriver from 4.9.0 to 4.9.1 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/255)