### PR TITLE
Combined dependency updates (2023-05-20)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -97,7 +97,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.11.0</version>
+			<version>2.12.0</version>
 		</dependency>
 	</dependencies>
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
 

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.9.1" />
 


### PR DESCRIPTION
Includes these updates:
- [Bump commons-io from 2.11.0 to 2.12.0 in /java](https://github.com/javiertuya/selema/pull/259)
- [Bump Microsoft.NET.Test.Sdk from 17.5.0 to 17.6.0 in /net](https://github.com/javiertuya/selema/pull/260)
- [Bump Microsoft.NET.Test.Sdk from 17.5.0 to 17.6.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/262)
- [Bump Microsoft.NET.Test.Sdk from 17.5.0 to 17.6.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/261)