### PR TITLE
Combined dependency updates (2023-05-28)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       packages: write 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3.0.3
+      - uses: actions/setup-dotnet@v3.1.0
         with:
             dotnet-version: '3.1.x'
       - name: Pack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
       #    skip_publishing: ${{ github.actor != 'javiertuya' }} #avoids failure on dependabot or other user PRs
       - name: Generate report checks1
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.6
+        uses: mikepenz/action-junit-report@v3.7.7
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: '8'
           cache: 'maven'
       - if: ${{ matrix.platform=='net' }}
-        uses: actions/setup-dotnet@v3.0.3
+        uses: actions/setup-dotnet@v3.1.0
         with:
             dotnet-version: '3.1.x'
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -218,7 +218,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>3.2.1</version>
+				<version>3.3.0</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -52,7 +52,7 @@
 
     <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
 
-    <PackageReference Include="NLog" Version="5.1.4" />
+    <PackageReference Include="NLog" Version="5.1.5" />
 
     <PackageReference Include="NUnit" Version="3.13.3" />
 

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.3" />
 
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
 

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.3" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.3" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.9.1" />
     


### PR DESCRIPTION
Includes these updates:
- [Bump actions/setup-dotnet from 3.0.3 to 3.1.0](https://github.com/javiertuya/selema/pull/266)
- [Bump mikepenz/action-junit-report from 3.7.6 to 3.7.7](https://github.com/javiertuya/selema/pull/265)
- [Bump maven-source-plugin from 3.2.1 to 3.3.0 in /java](https://github.com/javiertuya/selema/pull/264)
- [Bump NLog from 5.1.4 to 5.1.5 in /net](https://github.com/javiertuya/selema/pull/267)
- [Bump MSTest.TestAdapter from 3.0.2 to 3.0.3 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/269)
- [Bump MSTest.TestFramework from 3.0.2 to 3.0.3 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/268)