### PR TITLE
Combined dependency updates (2023-06-03)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       packages: write 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3.1.0
+      - uses: actions/setup-dotnet@v3.2.0
         with:
             dotnet-version: '3.1.x'
       - name: Pack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: '8'
           cache: 'maven'
       - if: ${{ matrix.platform=='net' }}
-        uses: actions/setup-dotnet@v3.1.0
+        uses: actions/setup-dotnet@v3.2.0
         with:
             dotnet-version: '3.1.x'
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -52,7 +52,7 @@
 
     <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
 
-    <PackageReference Include="NLog" Version="5.1.5" />
+    <PackageReference Include="NLog" Version="5.2.0" />
 
     <PackageReference Include="NUnit" Version="3.13.3" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.9.1" />
   </ItemGroup>
 

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
 

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
 
     <PackageReference Include="MSTest.TestFramework" Version="3.0.3" />
 

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.9.1" />
     

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.13.3" />
 
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
 

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.9.1" />
 


### PR DESCRIPTION
Includes these updates:
- [Bump actions/setup-dotnet from 3.1.0 to 3.2.0](https://github.com/javiertuya/selema/pull/271)
- [Bump Microsoft.NET.Test.Sdk from 17.6.0 to 17.6.1 in /net](https://github.com/javiertuya/selema/pull/275)
- [Bump NLog from 5.1.5 to 5.2.0 in /net](https://github.com/javiertuya/selema/pull/272)
- [Bump NUnit3TestAdapter from 4.4.2 to 4.5.0 in /net](https://github.com/javiertuya/selema/pull/273)
- [Bump MSTest.TestAdapter from 3.0.3 to 3.0.4 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/278)
- [Bump MSTest.TestFramework from 3.0.3 to 3.0.4 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/277)
- [Bump Microsoft.NET.Test.Sdk from 17.6.0 to 17.6.1 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/276)
- [Bump Microsoft.NET.Test.Sdk from 17.6.0 to 17.6.1 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/279)
- [Bump NUnit3TestAdapter from 4.4.2 to 4.5.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/274)