### PR TITLE
Combined dependency updates (2023-06-10)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -115,7 +115,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.1.2</version>
 				<configuration>
 					<testFailureIgnore>true</testFailureIgnore>
 					<!-- Sets the VM argument line used when unit tests are run under JaCoCo -->

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -162,7 +162,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.1.2</version>
 				<executions>
 					<execution>
 						<id>ut-reports</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -62,7 +62,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.9.1</version>
+			<version>4.10.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -97,7 +97,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.12.0</version>
+			<version>2.13.0</version>
 		</dependency>
 	</dependencies>
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -62,7 +62,7 @@
 
     <PackageReference Include="WebDriverManager" Version="2.16.2" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.9.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.10.0" />
   </ItemGroup>
 
 </Project>

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.9.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.9.1</version>
+			<version>4.10.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -47,7 +47,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.1.2</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.9.1</version>
+			<version>4.10.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.9.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.10.0" />
     
     <PackageReference Include="Selema" Version="3.0.3" />
   </ItemGroup>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
 

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.9.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.10.0" />
 
     <PackageReference Include="Selema" Version="3.0.3" />
   </ItemGroup>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.9.1" />
 


### PR DESCRIPTION
Includes these updates:
- [Bump commons-io from 2.12.0 to 2.13.0 in /java](https://github.com/javiertuya/selema/pull/288)
- [Bump maven-surefire-plugin from 3.1.0 to 3.1.2 in /java](https://github.com/javiertuya/selema/pull/281)
- [Bump maven-surefire-report-plugin from 3.1.0 to 3.1.2 in /java](https://github.com/javiertuya/selema/pull/282)
- [Bump selenium-java from 4.9.1 to 4.10.0 in /java](https://github.com/javiertuya/selema/pull/287)
- [Bump selenium-java from 4.9.1 to 4.10.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/293)
- [Bump maven-surefire-plugin from 3.1.0 to 3.1.2 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/286)
- [Bump selenium-java from 4.9.1 to 4.10.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/290)
- [Bump Microsoft.NET.Test.Sdk from 17.6.1 to 17.6.2 in /net](https://github.com/javiertuya/selema/pull/283)
- [Bump Selenium.WebDriver from 4.9.1 to 4.10.0 in /net](https://github.com/javiertuya/selema/pull/289)
- [Bump Microsoft.NET.Test.Sdk from 17.6.1 to 17.6.2 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/285)
- [Bump Selenium.WebDriver from 4.9.1 to 4.10.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/291)
- [Bump Microsoft.NET.Test.Sdk from 17.6.1 to 17.6.2 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/284)
- [Bump Selenium.WebDriver from 4.9.1 to 4.10.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/292)