### PR TITLE
Combined dependency updates (2023-06-17)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -81,7 +81,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>visual-assert</artifactId>
-			<version>2.3.0</version>
+			<version>2.4.1</version>
 		</dependency>
 
 		<dependency>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -58,7 +58,7 @@
 
     <PackageReference Include="PortableCs" Version="2.2.0" />
 
-    <PackageReference Include="VisualAssert" Version="2.2.2" />
+    <PackageReference Include="VisualAssert" Version="2.4.1" />
 
     <PackageReference Include="WebDriverManager" Version="2.16.2" />
 


### PR DESCRIPTION
Includes these updates:
- [Bump visual-assert from 2.3.0 to 2.4.1 in /java](https://github.com/javiertuya/selema/pull/295)
- [Bump VisualAssert from 2.2.2 to 2.4.1 in /net](https://github.com/javiertuya/selema/pull/296)