### PR TITLE
Combined dependency updates (2023-07-02)

### DIFF
--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -60,7 +60,7 @@
 
     <PackageReference Include="VisualAssert" Version="2.4.1" />
 
-    <PackageReference Include="WebDriverManager" Version="2.16.2" />
+    <PackageReference Include="WebDriverManager" Version="2.16.3" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.10.0" />
   </ItemGroup>

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
 

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.10.0" />
 


### PR DESCRIPTION
Includes these updates:
- [Bump Microsoft.NET.Test.Sdk from 17.6.2 to 17.6.3 in /net](https://github.com/javiertuya/selema/pull/304)
- [Bump WebDriverManager from 2.16.2 to 2.16.3 in /net](https://github.com/javiertuya/selema/pull/303)
- [Bump Microsoft.NET.Test.Sdk from 17.6.2 to 17.6.3 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/305)
- [Bump Microsoft.NET.Test.Sdk from 17.6.2 to 17.6.3 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/306)