### PR TITLE
Combined dependency updates (2023-07-09)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,7 +163,7 @@ jobs:
       run:
         working-directory: java
     steps:
-      - uses: javiertuya/branch-snapshots-action@v1.1.0
+      - uses: javiertuya/branch-snapshots-action@v1.2.0
         with: 
           token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: java

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,7 +145,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: javiertuya/sonarqube-action@v1.0.0
+      - uses: javiertuya/sonarqube-action@v1.1.0
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -50,7 +50,7 @@
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.48" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.49" />
 
     <PackageReference Include="NLog" Version="5.2.0" />
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -52,7 +52,7 @@
 
     <PackageReference Include="HtmlAgilityPack" Version="1.11.49" />
 
-    <PackageReference Include="NLog" Version="5.2.0" />
+    <PackageReference Include="NLog" Version="5.2.2" />
 
     <PackageReference Include="NUnit" Version="3.13.3" />
 


### PR DESCRIPTION
Includes these updates:
- [Bump javiertuya/branch-snapshots-action from 1.1.0 to 1.2.0](https://github.com/javiertuya/selema/pull/308)
- [Bump javiertuya/sonarqube-action from 1.0.0 to 1.1.0](https://github.com/javiertuya/selema/pull/309)
- [Bump HtmlAgilityPack from 1.11.48 to 1.11.49 in /net](https://github.com/javiertuya/selema/pull/312)
- [Bump NLog from 5.2.0 to 5.2.2 in /net](https://github.com/javiertuya/selema/pull/311)