### PR TITLE
Combined dependency updates (2023-07-22)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
       #    skip_publishing: ${{ github.actor != 'javiertuya' }} #avoids failure on dependabot or other user PRs
       - name: Generate report checks1
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.8
+        uses: mikepenz/action-junit-report@v3.8.0
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -76,7 +76,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>portable-java</artifactId>
-			<version>2.2.0</version>
+			<version>2.2.1</version>
 		</dependency>
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -50,7 +50,7 @@
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.49" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.50" />
 
     <PackageReference Include="NLog" Version="5.2.2" />
 

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
 
     <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
 

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.10.0" />
     


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 3.7.8 to 3.8.0](https://github.com/javiertuya/selema/pull/317)
- [Bump portable-java from 2.2.0 to 2.2.1 in /java](https://github.com/javiertuya/selema/pull/314)
- [Bump HtmlAgilityPack from 1.11.49 to 1.11.50 in /net](https://github.com/javiertuya/selema/pull/318)
- [Bump MSTest.TestAdapter from 3.0.4 to 3.1.1 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/315)
- [Bump MSTest.TestFramework from 3.0.4 to 3.1.1 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/316)