### PR TITLE
Combined dependency updates (2023-08-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,7 +145,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: javiertuya/sonarqube-action@v1.1.0
+      - uses: javiertuya/sonarqube-action@v1.1.1
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.10.0</version>
+			<version>4.11.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -60,7 +60,7 @@
 
     <PackageReference Include="VisualAssert" Version="2.4.1" />
 
-    <PackageReference Include="WebDriverManager" Version="2.16.3" />
+    <PackageReference Include="WebDriverManager" Version="2.17.0" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.11.0" />
   </ItemGroup>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -50,7 +50,7 @@
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.50" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.51" />
 
     <PackageReference Include="NLog" Version="5.2.2" />
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -62,7 +62,7 @@
 
     <PackageReference Include="WebDriverManager" Version="2.16.3" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.10.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.11.0" />
   </ItemGroup>
 
 </Project>

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -20,7 +20,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.10.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.10.0</version>
+			<version>4.11.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.0.3</version>
+			<version>3.0.4</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.10.0</version>
+			<version>4.11.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.0.3</version>
+			<version>3.0.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.10.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.11.0" />
     
     <PackageReference Include="Selema" Version="3.0.4" />
   </ItemGroup>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -16,7 +16,7 @@
 
     <PackageReference Include="Selenium.WebDriver" Version="4.10.0" />
     
-    <PackageReference Include="Selema" Version="3.0.3" />
+    <PackageReference Include="Selema" Version="3.0.4" />
   </ItemGroup>
 
 </Project>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -16,7 +16,7 @@
 
     <PackageReference Include="Selenium.WebDriver" Version="4.10.0" />
 
-    <PackageReference Include="Selema" Version="3.0.3" />
+    <PackageReference Include="Selema" Version="3.0.4" />
   </ItemGroup>
 
 </Project>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.10.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.11.0" />
 
     <PackageReference Include="Selema" Version="3.0.4" />
   </ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Bump javiertuya/sonarqube-action from 1.1.0 to 1.1.1](https://github.com/javiertuya/selema/pull/328)
- [Bump org.seleniumhq.selenium:selenium-java from 4.10.0 to 4.11.0 in /java](https://github.com/javiertuya/selema/pull/335)
- [Bump io.github.javiertuya:selema from 3.0.3 to 3.0.4 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/327)
- [Bump org.seleniumhq.selenium:selenium-java from 4.10.0 to 4.11.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/334)
- [Bump io.github.javiertuya:selema from 3.0.3 to 3.0.4 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/326)
- [Bump org.seleniumhq.selenium:selenium-java from 4.10.0 to 4.11.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/333)
- [Bump HtmlAgilityPack from 1.11.50 to 1.11.51 in /net](https://github.com/javiertuya/selema/pull/336)
- [Bump Selenium.WebDriver from 4.10.0 to 4.11.0 in /net](https://github.com/javiertuya/selema/pull/330)
- [Bump WebDriverManager from 2.16.3 to 2.17.0 in /net](https://github.com/javiertuya/selema/pull/329)
- [Bump Selema from 3.0.3 to 3.0.4 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/324)
- [Bump Selenium.WebDriver from 4.10.0 to 4.11.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/332)
- [Bump Selema from 3.0.3 to 3.0.4 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/325)
- [Bump Selenium.WebDriver from 4.10.0 to 4.11.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/331)