### PR TITLE
Combined dependency updates (2023-08-11)

### DIFF
--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -52,7 +52,7 @@
 
     <PackageReference Include="HtmlAgilityPack" Version="1.11.51" />
 
-    <PackageReference Include="NLog" Version="5.2.2" />
+    <PackageReference Include="NLog" Version="5.2.3" />
 
     <PackageReference Include="NUnit" Version="3.13.3" />
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -60,7 +60,7 @@
 
     <PackageReference Include="VisualAssert" Version="2.4.1" />
 
-    <PackageReference Include="WebDriverManager" Version="2.17.0" />
+    <PackageReference Include="WebDriverManager" Version="2.17.1" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.11.0" />
   </ItemGroup>

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
 
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
 

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
 

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.11.0" />
 


### PR DESCRIPTION
Includes these updates:
- [Bump Microsoft.NET.Test.Sdk from 17.6.3 to 17.7.0 in /net](https://github.com/javiertuya/selema/pull/338)
- [Bump NLog from 5.2.2 to 5.2.3 in /net](https://github.com/javiertuya/selema/pull/339)
- [Bump WebDriverManager from 2.17.0 to 2.17.1 in /net](https://github.com/javiertuya/selema/pull/340)
- [Bump Microsoft.NET.Test.Sdk from 17.6.3 to 17.7.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/341)
- [Bump Microsoft.NET.Test.Sdk from 17.6.3 to 17.7.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/342)