### PR TITLE
Combined dependency updates (2023-08-18)

### DIFF
--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -56,7 +56,7 @@
 
     <PackageReference Include="NUnit" Version="3.13.3" />
 
-    <PackageReference Include="PortableCs" Version="2.2.0" />
+    <PackageReference Include="PortableCs" Version="2.2.2" />
 
     <PackageReference Include="VisualAssert" Version="2.4.1" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
 
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
 

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.0.4</version>
+			<version>3.1.1</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.0.4</version>
+			<version>3.1.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -16,7 +16,7 @@
 
     <PackageReference Include="Selenium.WebDriver" Version="4.11.0" />
     
-    <PackageReference Include="Selema" Version="3.0.4" />
+    <PackageReference Include="Selema" Version="3.1.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
 

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.11.0" />
 

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -16,7 +16,7 @@
 
     <PackageReference Include="Selenium.WebDriver" Version="4.11.0" />
 
-    <PackageReference Include="Selema" Version="3.0.4" />
+    <PackageReference Include="Selema" Version="3.1.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Includes these updates:
- [Bump io.github.javiertuya:selema from 3.0.4 to 3.1.1 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/352)
- [Bump io.github.javiertuya:selema from 3.0.4 to 3.1.1 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/355)
- [Bump Microsoft.NET.Test.Sdk from 17.7.0 to 17.7.1 in /net](https://github.com/javiertuya/selema/pull/349)
- [Bump PortableCs from 2.2.0 to 2.2.2 in /net](https://github.com/javiertuya/selema/pull/350)
- [Bump Microsoft.NET.Test.Sdk from 17.7.0 to 17.7.1 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/348)
- [Bump Selema from 3.0.4 to 3.1.1 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/353)
- [Bump Microsoft.NET.Test.Sdk from 17.7.0 to 17.7.1 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/345)
- [Bump Selema from 3.0.4 to 3.1.1 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/354)