### PR TITLE
Combined dependency updates (2023-08-26)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -70,7 +70,7 @@
 		<dependency>
 			<groupId>io.github.bonigarcia</groupId>
 			<artifactId>webdrivermanager</artifactId>
-			<version>5.4.1</version>
+			<version>5.5.0</version>
 		</dependency>
 
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -205,7 +205,7 @@
 					<dependency>
 						<groupId>org.apache.ant</groupId>
 						<artifactId>ant-junit</artifactId>
-						<version>1.10.13</version>
+						<version>1.10.14</version>
 					</dependency>
 					<dependency>
 						<groupId>org.apache.ant</groupId>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -50,7 +50,7 @@
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.51" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.52" />
 
     <PackageReference Include="NLog" Version="5.2.3" />
 


### PR DESCRIPTION
Includes these updates:
- [Bump io.github.bonigarcia:webdrivermanager from 5.4.1 to 5.5.0 in /java](https://github.com/javiertuya/selema/pull/358)
- [Bump org.apache.ant:ant-junit from 1.10.13 to 1.10.14 in /java](https://github.com/javiertuya/selema/pull/359)
- [Bump HtmlAgilityPack from 1.11.51 to 1.11.52 in /net](https://github.com/javiertuya/selema/pull/357)