### PR TITLE
Combined dependency updates (2023-09-02)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -70,7 +70,7 @@
 		<dependency>
 			<groupId>io.github.bonigarcia</groupId>
 			<artifactId>webdrivermanager</artifactId>
-			<version>5.5.0</version>
+			<version>5.5.2</version>
 		</dependency>
 
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.11.0</version>
+			<version>4.12.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
 
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
 

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.11.0</version>
+			<version>4.12.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.11.0</version>
+			<version>4.12.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
 

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.11.0" />
 


### PR DESCRIPTION
Includes these updates:
- [Bump io.github.bonigarcia:webdrivermanager from 5.5.0 to 5.5.2 in /java](https://github.com/javiertuya/selema/pull/367)
- [Bump org.seleniumhq.selenium:selenium-java from 4.11.0 to 4.12.0 in /java](https://github.com/javiertuya/selema/pull/366)
- [Bump org.seleniumhq.selenium:selenium-java from 4.11.0 to 4.12.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/365)
- [Bump org.seleniumhq.selenium:selenium-java from 4.11.0 to 4.12.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/370)
- [Bump Microsoft.NET.Test.Sdk from 17.7.1 to 17.7.2 in /net](https://github.com/javiertuya/selema/pull/361)
- [Bump Microsoft.NET.Test.Sdk from 17.7.1 to 17.7.2 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/363)
- [Bump Microsoft.NET.Test.Sdk from 17.7.1 to 17.7.2 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/369)