### PR TITLE
Combined dependency updates (2023-09-30)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.12.1</version>
+			<version>4.13.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -230,7 +230,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.5.0</version>
+				<version>3.6.0</version>
 				<configuration>
 					<quiet>true</quiet>
 					<doclint>none</doclint>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -62,7 +62,7 @@
 
     <PackageReference Include="WebDriverManager" Version="2.17.1" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.12.4" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.13.1" />
   </ItemGroup>
 
 </Project>

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -20,7 +20,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.12.4" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.13.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.12.1</version>
+			<version>4.13.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.12.1</version>
+			<version>4.13.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.12.4" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.13.1" />
     
     <PackageReference Include="Selema" Version="3.1.1" />
   </ItemGroup>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.12.4" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.13.1" />
 
     <PackageReference Include="Selema" Version="3.1.1" />
   </ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.5.0 to 3.6.0 in /java](https://github.com/javiertuya/selema/pull/390)
- [Bump org.seleniumhq.selenium:selenium-java from 4.12.1 to 4.13.0 in /java](https://github.com/javiertuya/selema/pull/391)
- [Bump org.seleniumhq.selenium:selenium-java from 4.12.1 to 4.13.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/395)
- [Bump org.seleniumhq.selenium:selenium-java from 4.12.1 to 4.13.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/393)
- [Bump Selenium.WebDriver from 4.12.4 to 4.13.1 in /net](https://github.com/javiertuya/selema/pull/392)
- [Bump Selenium.WebDriver from 4.12.4 to 4.13.1 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/394)
- [Bump Selenium.WebDriver from 4.12.4 to 4.13.1 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/396)