### PR TITLE
Combined dependency updates (2023-10-07)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,6 +118,7 @@ jobs:
             java/target/selema/*.png
             java/target/selema/video*.mp4
             net/reports
+            !**/selenoid*.mp4
       - name: JAVA - Reports for Sonar
         if: ${{ always() && matrix.platform=='java' }}
         uses: actions/upload-artifact@v3.1.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
       #    skip_publishing: ${{ github.actor != 'javiertuya' }} #avoids failure on dependabot or other user PRs
       - name: Generate report checks1
         if: always()
-        uses: mikepenz/action-junit-report@v4.0.0
+        uses: mikepenz/action-junit-report@v4.0.1
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -99,7 +99,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.13.0</version>
+			<version>2.14.0</version>
 		</dependency>
 	</dependencies>
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -50,7 +50,7 @@
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.53" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.54" />
 
     <PackageReference Include="NLog" Version="5.2.4" />
 


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 4.0.0 to 4.0.1](https://github.com/javiertuya/selema/pull/398)
- [Bump commons-io:commons-io from 2.13.0 to 2.14.0 in /java](https://github.com/javiertuya/selema/pull/399)
- [Bump HtmlAgilityPack from 1.11.53 to 1.11.54 in /net](https://github.com/javiertuya/selema/pull/400)
- [Avoid upload-artifact hang when copying selenoid video files](https://github.com/javiertuya/selema/pull/401)