### PR TITLE
Combined dependency updates (2023-10-14)

### DIFF
--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -62,7 +62,7 @@
 
     <PackageReference Include="WebDriverManager" Version="2.17.1" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.13.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.14.0" />
   </ItemGroup>
 
 </Project>

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -20,7 +20,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.13.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.14.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.13.0</version>
+			<version>4.14.1</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.13.0</version>
+			<version>4.14.1</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.13.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.14.0" />
     
     <PackageReference Include="Selema" Version="3.1.1" />
   </ItemGroup>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.13.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.14.0" />
 
     <PackageReference Include="Selema" Version="3.1.1" />
   </ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Bump org.seleniumhq.selenium:selenium-java from 4.13.0 to 4.14.1 in /java](https://github.com/javiertuya/selema/pull/404)
- [Bump org.seleniumhq.selenium:selenium-java from 4.13.0 to 4.14.1 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/406)
- [Bump org.seleniumhq.selenium:selenium-java from 4.13.0 to 4.14.1 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/405)
- [Bump Selenium.WebDriver from 4.13.1 to 4.14.0 in /net](https://github.com/javiertuya/selema/pull/408)
- [Bump Selenium.WebDriver from 4.13.1 to 4.14.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/407)
- [Bump Selenium.WebDriver from 4.13.1 to 4.14.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/403)