### PR TITLE
Combined dependency updates (2023-10-20)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -136,7 +136,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.10</version>
+				<version>0.8.11</version>
 				<executions>
 					<execution>
 						<id>pre-unit-test</id>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -52,7 +52,7 @@
 
     <PackageReference Include="HtmlAgilityPack" Version="1.11.54" />
 
-    <PackageReference Include="NLog" Version="5.2.4" />
+    <PackageReference Include="NLog" Version="5.2.5" />
 
     <PackageReference Include="NUnit" Version="3.13.3" />
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -62,7 +62,7 @@
 
     <PackageReference Include="WebDriverManager" Version="2.17.1" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.14.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.14.1" />
   </ItemGroup>
 
 </Project>

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -20,7 +20,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.14.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.14.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.14.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.14.1" />
     
     <PackageReference Include="Selema" Version="3.1.1" />
   </ItemGroup>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.14.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.14.1" />
 
     <PackageReference Include="Selema" Version="3.1.1" />
   </ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Bump org.jacoco:jacoco-maven-plugin from 0.8.10 to 0.8.11 in /java](https://github.com/javiertuya/selema/pull/410)
- [Bump NLog from 5.2.4 to 5.2.5 in /net](https://github.com/javiertuya/selema/pull/411)
- [Bump Selenium.WebDriver from 4.14.0 to 4.14.1 in /net](https://github.com/javiertuya/selema/pull/412)
- [Bump Selenium.WebDriver from 4.14.0 to 4.14.1 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/414)
- [Bump Selenium.WebDriver from 4.14.0 to 4.14.1 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/413)