### PR TITLE
Combined dependency updates (2023-11-04)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
       #    skip_publishing: ${{ github.actor != 'javiertuya' }} #avoids failure on dependabot or other user PRs
       - name: Generate report checks1
         if: always()
-        uses: mikepenz/action-junit-report@v4.0.1
+        uses: mikepenz/action-junit-report@v4.0.3
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -25,7 +25,7 @@
 
 		<junit.version>4.13.2</junit.version>
 		
-		<surefire.version>3.1.2</surefire.version>
+		<surefire.version>3.2.1</surefire.version>
 		
 		<slf4j.version>2.0.9</slf4j.version>
 	</properties>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -70,7 +70,7 @@
 		<dependency>
 			<groupId>io.github.bonigarcia</groupId>
 			<artifactId>webdrivermanager</artifactId>
-			<version>5.5.3</version>
+			<version>5.6.0</version>
 		</dependency>
 
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.14.1</version>
+			<version>4.15.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -99,7 +99,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.14.0</version>
+			<version>2.15.0</version>
 		</dependency>
 	</dependencies>
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -62,7 +62,7 @@
 
     <PackageReference Include="WebDriverManager" Version="2.17.1" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.14.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.15.0" />
   </ItemGroup>
 
 </Project>

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -20,7 +20,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.14.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.15.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.14.1</version>
+			<version>4.15.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.14.1</version>
+			<version>4.15.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -47,7 +47,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.1.2</version>
+				<version>3.2.1</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.14.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.15.0" />
     
     <PackageReference Include="Selema" Version="3.1.1" />
   </ItemGroup>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.14.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.15.0" />
 
     <PackageReference Include="Selema" Version="3.1.1" />
   </ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 4.0.1 to 4.0.3](https://github.com/javiertuya/selema/pull/417)
- [Bump commons-io:commons-io from 2.14.0 to 2.15.0 in /java](https://github.com/javiertuya/selema/pull/419)
- [Bump io.github.bonigarcia:webdrivermanager from 5.5.3 to 5.6.0 in /java](https://github.com/javiertuya/selema/pull/427)
- [Bump org.seleniumhq.selenium:selenium-java from 4.14.1 to 4.15.0 in /java](https://github.com/javiertuya/selema/pull/426)
- [Bump surefire.version from 3.1.2 to 3.2.1 in /java](https://github.com/javiertuya/selema/pull/420)
- [Bump org.seleniumhq.selenium:selenium-java from 4.14.1 to 4.15.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/422)
- [Bump org.apache.maven.plugins:maven-surefire-plugin from 3.1.2 to 3.2.1 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/418)
- [Bump org.seleniumhq.selenium:selenium-java from 4.14.1 to 4.15.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/421)
- [Bump Selenium.WebDriver from 4.14.1 to 4.15.0 in /net](https://github.com/javiertuya/selema/pull/423)
- [Bump Selenium.WebDriver from 4.14.1 to 4.15.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/424)
- [Bump Selenium.WebDriver from 4.14.1 to 4.15.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/425)