### PR TITLE
Combined dependency updates (2023-11-11)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 
-		<junit-jupiter.version>5.10.0</junit-jupiter.version>
+		<junit-jupiter.version>5.10.1</junit-jupiter.version>
 
 		<junit.version>4.13.2</junit.version>
 		

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -70,7 +70,7 @@
 		<dependency>
 			<groupId>io.github.bonigarcia</groupId>
 			<artifactId>webdrivermanager</artifactId>
-			<version>5.6.0</version>
+			<version>5.6.2</version>
 		</dependency>
 
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -25,7 +25,7 @@
 
 		<junit.version>4.13.2</junit.version>
 		
-		<surefire.version>3.2.1</surefire.version>
+		<surefire.version>3.2.2</surefire.version>
 		
 		<slf4j.version>2.0.9</slf4j.version>
 	</properties>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -230,7 +230,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.6.0</version>
+				<version>3.6.2</version>
 				<configuration>
 					<quiet>true</quiet>
 					<doclint>none</doclint>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -54,7 +54,7 @@
 
     <PackageReference Include="NLog" Version="5.2.5" />
 
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
 
     <PackageReference Include="PortableCs" Version="2.2.2" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -16,7 +16,7 @@
 
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
 
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
 

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -47,7 +47,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.2.1</version>
+				<version>3.2.2</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.10.0</version>
+			<version>5.10.1</version>
 		</dependency>
 		<dependency>
 		   <groupId>io.github.artsok</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
 

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.15.0" />
 

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 


### PR DESCRIPTION
Includes these updates:
- [Bump io.github.bonigarcia:webdrivermanager from 5.6.0 to 5.6.2 in /java](https://github.com/javiertuya/selema/pull/438)
- [Bump junit-jupiter.version from 5.10.0 to 5.10.1 in /java](https://github.com/javiertuya/selema/pull/435)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.6.0 to 3.6.2 in /java](https://github.com/javiertuya/selema/pull/436)
- [Bump surefire.version from 3.2.1 to 3.2.2 in /java](https://github.com/javiertuya/selema/pull/437)
- [Bump org.apache.maven.plugins:maven-surefire-plugin from 3.2.1 to 3.2.2 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/433)
- [Bump org.junit.jupiter:junit-jupiter-engine from 5.10.0 to 5.10.1 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/434)
- [Bump Microsoft.NET.Test.Sdk from 17.7.2 to 17.8.0 in /net](https://github.com/javiertuya/selema/pull/431)
- [Bump NUnit from 3.13.3 to 3.14.0 in /net](https://github.com/javiertuya/selema/pull/432)
- [Bump Microsoft.NET.Test.Sdk from 17.7.2 to 17.8.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/439)
- [Bump Microsoft.NET.Test.Sdk from 17.7.2 to 17.8.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/429)
- [Bump NUnit from 3.13.3 to 3.14.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/430)