### PR TITLE
Combined dependency updates (2023-12-02)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           gpg_private_key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
       - name: Set up Apache Maven Central
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with: # running setup-java again overwrites the settings.xml
           distribution: 'temurin'
           java-version: '11'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - if: ${{ matrix.platform=='java' }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '11'

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -99,7 +99,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.15.0</version>
+			<version>2.15.1</version>
 		</dependency>
 	</dependencies>
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -52,7 +52,7 @@
 
     <PackageReference Include="HtmlAgilityPack" Version="1.11.54" />
 
-    <PackageReference Include="NLog" Version="5.2.5" />
+    <PackageReference Include="NLog" Version="5.2.7" />
 
     <PackageReference Include="NUnit" Version="3.14.0" />
 


### PR DESCRIPTION
Includes these updates:
- [Bump actions/setup-java from 3 to 4](https://github.com/javiertuya/selema/pull/443)
- [Bump commons-io:commons-io from 2.15.0 to 2.15.1 in /java](https://github.com/javiertuya/selema/pull/445)
- [Bump NLog from 5.2.5 to 5.2.7 in /net](https://github.com/javiertuya/selema/pull/444)