### PR TITLE
Combined dependency updates (2023-12-17)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
 
       - if: always()
         name: Publish test report files
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: "test-report-${{ matrix.platform }}-${{ matrix.mode }}-files"
           path: |
@@ -121,7 +121,7 @@ jobs:
             !**/selenoid*.mp4
       - name: JAVA - Reports for Sonar
         if: ${{ always() && matrix.platform=='java' }}
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: "sonar-${{ matrix.platform }}-${{ matrix.mode }}"
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
 
       - if: always()
         name: Publish test report files
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: "test-report-${{ matrix.platform }}-${{ matrix.mode }}-files"
           path: |
@@ -121,7 +121,7 @@ jobs:
             !**/selenoid*.mp4
       - name: JAVA - Reports for Sonar
         if: ${{ always() && matrix.platform=='java' }}
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: "sonar-${{ matrix.platform }}-${{ matrix.mode }}"
           path: |

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -25,7 +25,7 @@
 
 		<junit.version>4.13.2</junit.version>
 		
-		<surefire.version>3.2.2</surefire.version>
+		<surefire.version>3.2.3</surefire.version>
 		
 		<slf4j.version>2.0.9</slf4j.version>
 	</properties>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -50,7 +50,7 @@
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.54" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.55" />
 
     <PackageReference Include="NLog" Version="5.2.7" />
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -62,7 +62,7 @@
 
     <PackageReference Include="WebDriverManager" Version="2.17.1" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.16.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.16.2" />
   </ItemGroup>
 
 </Project>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -47,7 +47,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.2.2</version>
+				<version>3.2.3</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.16.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.16.2" />
     
     <PackageReference Include="Selema" Version="3.2.0" />
   </ItemGroup>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.16.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.16.2" />
 
     <PackageReference Include="Selema" Version="3.2.0" />
   </ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Bump surefire.version from 3.2.2 to 3.2.3 in /java](https://github.com/javiertuya/selema/pull/467)
- [Bump org.apache.maven.plugins:maven-surefire-plugin from 3.2.2 to 3.2.3 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/472)
- [Bump HtmlAgilityPack from 1.11.54 to 1.11.55 in /net/Selema](https://github.com/javiertuya/selema/pull/469)
- [Bump Selenium.WebDriver from 4.16.1 to 4.16.2 in /net/Selema](https://github.com/javiertuya/selema/pull/468)
- [Bump HtmlAgilityPack from 1.11.54 to 1.11.55 in /net/SelemaTest](https://github.com/javiertuya/selema/pull/470)
- [Bump Selenium.WebDriver from 4.16.1 to 4.16.2 in /net/SelemaTest](https://github.com/javiertuya/selema/pull/464)
- [Bump Selenium.WebDriver from 4.16.1 to 4.16.2 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/471)
- [Bump Selenium.WebDriver from 4.16.1 to 4.16.2 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/466)