### PR TITLE
Combined dependency updates (2023-12-24)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -108,7 +108,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.11.0</version>
+				<version>3.12.0</version>
 				<configuration>
 					<source>11</source>
 					<target>11</target>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -50,7 +50,7 @@
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.55" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.56" />
 
     <PackageReference Include="NLog" Version="5.2.7" />
 


### PR DESCRIPTION
Includes these updates:
- [Bump org.apache.maven.plugins:maven-compiler-plugin from 3.11.0 to 3.12.0 in /java](https://github.com/javiertuya/selema/pull/475)
- [Bump HtmlAgilityPack from 1.11.55 to 1.11.56 in /net/Selema](https://github.com/javiertuya/selema/pull/476)
- [Bump HtmlAgilityPack from 1.11.55 to 1.11.56 in /net/SelemaTest](https://github.com/javiertuya/selema/pull/474)