### PR TITLE
Combined dependency updates (2023-12-30)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       #https://stackoverflow.com/questions/61096521/how-to-use-gpg-key-in-github-actions
       #It requires export the private key with the armor option: gpg --output private.pgm --armor --export-secret-key <email>
       - name: Import GPG Key 
-        uses: crazy-max/ghaction-import-gpg@v6.0.0
+        uses: crazy-max/ghaction-import-gpg@v6.1.0
         with:
           gpg_private_key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -108,7 +108,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.11.0</version>
+				<version>3.12.1</version>
 				<configuration>
 					<source>11</source>
 					<target>11</target>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -27,7 +27,7 @@
 		
 		<surefire.version>3.2.3</surefire.version>
 		
-		<slf4j.version>2.0.9</slf4j.version>
+		<slf4j.version>2.0.10</slf4j.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -50,7 +50,7 @@
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.55" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.57" />
 
     <PackageReference Include="NLog" Version="5.2.7" />
 


### PR DESCRIPTION
Includes these updates:
- [Bump crazy-max/ghaction-import-gpg from 6.0.0 to 6.1.0](https://github.com/javiertuya/selema/pull/481)
- [Bump org.apache.maven.plugins:maven-compiler-plugin from 3.11.0 to 3.12.1 in /java](https://github.com/javiertuya/selema/pull/479)
- [Bump slf4j.version from 2.0.9 to 2.0.10 in /java](https://github.com/javiertuya/selema/pull/478)
- [Bump HtmlAgilityPack from 1.11.55 to 1.11.57 in /net/Selema](https://github.com/javiertuya/selema/pull/480)
- [Bump HtmlAgilityPack from 1.11.55 to 1.11.57 in /net/SelemaTest](https://github.com/javiertuya/selema/pull/482)