### PR TITLE
Combined dependency updates (2024-01-14)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -70,7 +70,7 @@
 		<dependency>
 			<groupId>io.github.bonigarcia</groupId>
 			<artifactId>webdrivermanager</artifactId>
-			<version>5.6.2</version>
+			<version>5.6.3</version>
 		</dependency>
 
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -25,7 +25,7 @@
 
 		<junit.version>4.13.2</junit.version>
 		
-		<surefire.version>3.2.3</surefire.version>
+		<surefire.version>3.2.5</surefire.version>
 		
 		<slf4j.version>2.0.11</slf4j.version>
 	</properties>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -27,7 +27,7 @@
 		
 		<surefire.version>3.2.3</surefire.version>
 		
-		<slf4j.version>2.0.10</slf4j.version>
+		<slf4j.version>2.0.11</slf4j.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -52,7 +52,7 @@
 
     <PackageReference Include="HtmlAgilityPack" Version="1.11.57" />
 
-    <PackageReference Include="NLog" Version="5.2.7" />
+    <PackageReference Include="NLog" Version="5.2.8" />
 
     <PackageReference Include="NUnit" Version="3.14.0" />
 

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -47,7 +47,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.2.3</version>
+				<version>3.2.5</version>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Includes these updates:
- [Bump io.github.bonigarcia:webdrivermanager from 5.6.2 to 5.6.3 in /java](https://github.com/javiertuya/selema/pull/484)
- [Bump slf4j.version from 2.0.10 to 2.0.11 in /java](https://github.com/javiertuya/selema/pull/489)
- [Bump surefire.version from 3.2.3 to 3.2.5 in /java](https://github.com/javiertuya/selema/pull/488)
- [Bump org.apache.maven.plugins:maven-surefire-plugin from 3.2.3 to 3.2.5 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/487)
- [Bump NLog from 5.2.7 to 5.2.8 in /net/Selema](https://github.com/javiertuya/selema/pull/485)
- [Bump NLog from 5.2.7 to 5.2.8 in /net/SelemaTest](https://github.com/javiertuya/selema/pull/486)