### PR TITLE
Combined dependency updates (2024-01-27)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: javiertuya/sonarqube-action@v1.2.0
+      - uses: javiertuya/sonarqube-action@v1.3.0
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
       #    skip_publishing: ${{ github.actor != 'javiertuya' }} #avoids failure on dependabot or other user PRs
       - name: Generate report checks1
         if: always()
-        uses: mikepenz/action-junit-report@v4.0.3
+        uses: mikepenz/action-junit-report@v4.0.4
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
 
       - if: always()
         name: Publish test report files
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4.3.0
         with:
           name: "test-report-${{ matrix.platform }}-${{ matrix.mode }}-files"
           path: |
@@ -121,7 +121,7 @@ jobs:
             !**/selenoid*.mp4
       - name: JAVA - Reports for Sonar
         if: ${{ always() && matrix.platform=='java' }}
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4.3.0
         with:
           name: "sonar-${{ matrix.platform }}-${{ matrix.mode }}"
           path: |

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.16.1</version>
+			<version>4.17.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -62,7 +62,7 @@
 
     <PackageReference Include="WebDriverManager" Version="2.17.1" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.16.2" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.17.0" />
   </ItemGroup>
 
 </Project>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -46,7 +46,7 @@
     <!-- required only for selenium 3
     <PackageReference Include="Microsoft.Edge.SeleniumTools" Version="3.141.2" />
     -->
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
 
     <PackageReference Include="NUnit" Version="4.0.0" />
 

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.16.1</version>
+			<version>4.17.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.16.1</version>
+			<version>4.17.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.16.2" />
     

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
 
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
 

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.16.2" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.17.0" />
     
     <PackageReference Include="Selema" Version="3.2.0" />
   </ItemGroup>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.16.2" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.17.0" />
 
     <PackageReference Include="Selema" Version="3.2.0" />
   </ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Update sonarqube-action to v1.3.0](https://github.com/javiertuya/selema/pull/506/commits/88a4e4d39eb68d860bd734e60774cbbc9c611d09)
- [Bump actions/upload-artifact from 4.0.0 to 4.3.0](https://github.com/javiertuya/selema/pull/500)
- [Bump mikepenz/action-junit-report from 4.0.3 to 4.0.4](https://github.com/javiertuya/selema/pull/491)
- [Bump org.seleniumhq.selenium:selenium-java from 4.16.1 to 4.17.0 in /java](https://github.com/javiertuya/selema/pull/499)
- [Bump org.seleniumhq.selenium:selenium-java from 4.16.1 to 4.17.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/505)
- [Bump org.seleniumhq.selenium:selenium-java from 4.16.1 to 4.17.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/504)
- [Bump Selenium.WebDriver from 4.16.2 to 4.17.0 in /net/Selema](https://github.com/javiertuya/selema/pull/501)
- [Bump MSTest.TestAdapter from 3.1.1 to 3.2.0 in /net/SelemaTest](https://github.com/javiertuya/selema/pull/496)
- [Bump MSTest.TestFramework from 3.1.1 to 3.2.0 in /net/SelemaTest](https://github.com/javiertuya/selema/pull/498)
- [Bump Selenium.WebDriver from 4.16.2 to 4.17.0 in /net/SelemaTest](https://github.com/javiertuya/selema/pull/497)
- [Bump MSTest.TestAdapter from 3.1.1 to 3.2.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/495)
- [Bump MSTest.TestFramework from 3.1.1 to 3.2.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/493)
- [Bump Selenium.WebDriver from 4.16.2 to 4.17.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/494)
- [Bump Selenium.WebDriver from 4.16.2 to 4.17.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/503)