### PR TITLE
Combined dependency updates (2024-02-10)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
 
       - if: always()
         name: Publish test report files
-        uses: actions/upload-artifact@v4.3.0
+        uses: actions/upload-artifact@v4.3.1
         with:
           name: "test-report-${{ matrix.platform }}-${{ matrix.mode }}-files"
           path: |
@@ -121,7 +121,7 @@ jobs:
             !**/selenoid*.mp4
       - name: JAVA - Reports for Sonar
         if: ${{ always() && matrix.platform=='java' }}
-        uses: actions/upload-artifact@v4.3.0
+        uses: actions/upload-artifact@v4.3.1
         with:
           name: "sonar-${{ matrix.platform }}-${{ matrix.mode }}"
           path: |

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 
-		<junit-jupiter.version>5.10.1</junit-jupiter.version>
+		<junit-jupiter.version>5.10.2</junit-jupiter.version>
 
 		<junit.version>4.13.2</junit.version>
 		

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -27,7 +27,7 @@
 		
 		<surefire.version>3.2.5</surefire.version>
 		
-		<slf4j.version>2.0.11</slf4j.version>
+		<slf4j.version>2.0.12</slf4j.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 
     <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
 

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.10.1</version>
+			<version>5.10.2</version>
 		</dependency>
 		<dependency>
 		   <groupId>io.github.artsok</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
 

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.17.0" />
 


### PR DESCRIPTION
Includes these updates:
- [Bump actions/upload-artifact from 4.3.0 to 4.3.1](https://github.com/javiertuya/selema/pull/514)
- [Bump junit-jupiter.version from 5.10.1 to 5.10.2 in /java](https://github.com/javiertuya/selema/pull/512)
- [Bump slf4j.version from 2.0.11 to 2.0.12 in /java](https://github.com/javiertuya/selema/pull/513)
- [Bump org.junit.jupiter:junit-jupiter-engine from 5.10.1 to 5.10.2 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/515)
- [Bump Microsoft.NET.Test.Sdk from 17.8.0 to 17.9.0 in /net/SelemaTest](https://github.com/javiertuya/selema/pull/517)
- [Bump Microsoft.NET.Test.Sdk from 17.8.0 to 17.9.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/511)
- [Bump Microsoft.NET.Test.Sdk from 17.8.0 to 17.9.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/516)