### PR TITLE
Combined dependency updates (2024-02-18)

### DIFF
--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -50,7 +50,7 @@
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.58" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.59" />
 
     <PackageReference Include="NLog" Version="5.2.8" />
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -46,7 +46,7 @@
     <!-- required only for selenium 3
     <PackageReference Include="Microsoft.Edge.SeleniumTools" Version="3.141.2" />
     -->
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.1" />
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.1" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.1" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.1" />
 
     <PackageReference Include="NUnit" Version="4.0.0" />
 

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.1" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.1" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.17.0" />
     

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.1" />
 
     <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
 


### PR DESCRIPTION
Includes these updates:
- [Bump HtmlAgilityPack from 1.11.58 to 1.11.59 in /net/Selema](https://github.com/javiertuya/selema/pull/522)
- [Bump MSTest.TestFramework from 3.2.0 to 3.2.1 in /net/Selema](https://github.com/javiertuya/selema/pull/521)
- [Bump HtmlAgilityPack from 1.11.58 to 1.11.59 in /net/SelemaTest](https://github.com/javiertuya/selema/pull/523)
- [Bump MSTest.TestAdapter from 3.2.0 to 3.2.1 in /net/SelemaTest](https://github.com/javiertuya/selema/pull/524)
- [Bump MSTest.TestFramework from 3.2.0 to 3.2.1 in /net/SelemaTest](https://github.com/javiertuya/selema/pull/525)
- [Bump MSTest.TestAdapter from 3.2.0 to 3.2.1 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/519)
- [Bump MSTest.TestFramework from 3.2.0 to 3.2.1 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/520)