### PR TITLE
Combined dependency updates (2024-02-24)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.17.0</version>
+			<version>4.18.1</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -46,7 +46,7 @@
     <!-- required only for selenium 3
     <PackageReference Include="Microsoft.Edge.SeleniumTools" Version="3.141.2" />
     -->
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -60,7 +60,7 @@
 
     <PackageReference Include="VisualAssert" Version="2.4.1" />
 
-    <PackageReference Include="WebDriverManager" Version="2.17.1" />
+    <PackageReference Include="WebDriverManager" Version="2.17.2" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.18.1" />
   </ItemGroup>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -62,7 +62,7 @@
 
     <PackageReference Include="WebDriverManager" Version="2.17.1" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.17.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.18.1" />
   </ItemGroup>
 
 </Project>

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.2.1" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
 
     <PackageReference Include="NUnit" Version="4.0.0" />
 

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.17.0</version>
+			<version>4.18.1</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.17.0</version>
+			<version>4.18.1</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.17.0" />
     

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.17.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.18.1" />
     
     <PackageReference Include="Selema" Version="3.2.0" />
   </ItemGroup>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
 
     <PackageReference Include="MSTest.TestFramework" Version="3.2.1" />
 

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.17.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.18.1" />
 
     <PackageReference Include="Selema" Version="3.2.0" />
   </ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Bump org.seleniumhq.selenium:selenium-java from 4.17.0 to 4.18.1 in /java](https://github.com/javiertuya/selema/pull/533)
- [Bump org.seleniumhq.selenium:selenium-java from 4.17.0 to 4.18.1 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/541)
- [Bump org.seleniumhq.selenium:selenium-java from 4.17.0 to 4.18.1 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/527)
- [Bump MSTest.TestFramework from 3.2.1 to 3.2.2 in /net/Selema](https://github.com/javiertuya/selema/pull/531)
- [Bump Selenium.WebDriver from 4.17.0 to 4.18.1 in /net/Selema](https://github.com/javiertuya/selema/pull/529)
- [Bump WebDriverManager from 2.17.1 to 2.17.2 in /net/Selema](https://github.com/javiertuya/selema/pull/530)
- [Bump MSTest.TestAdapter from 3.2.1 to 3.2.2 in /net/SelemaTest](https://github.com/javiertuya/selema/pull/537)
- [Bump MSTest.TestFramework from 3.2.1 to 3.2.2 in /net/SelemaTest](https://github.com/javiertuya/selema/pull/535)
- [Bump Selenium.WebDriver from 4.17.0 to 4.18.1 in /net/SelemaTest](https://github.com/javiertuya/selema/pull/536)
- [Bump WebDriverManager from 2.17.1 to 2.17.2 in /net/SelemaTest](https://github.com/javiertuya/selema/pull/534)
- [Bump MSTest.TestAdapter from 3.2.1 to 3.2.2 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/539)
- [Bump MSTest.TestFramework from 3.2.1 to 3.2.2 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/540)
- [Bump Selenium.WebDriver from 4.17.0 to 4.18.1 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/538)
- [Bump Selenium.WebDriver from 4.17.0 to 4.18.1 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/528)