### PR TITLE
Combined dependency updates (2024-03-09)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,7 @@ jobs:
       run:
         working-directory: java
     steps:
-      - uses: javiertuya/branch-snapshots-action@v1.2.1
+      - uses: javiertuya/branch-snapshots-action@v1.2.2
         with: 
           token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: java

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.2.0</version>
+			<version>3.2.1</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.2.0</version>
+			<version>3.2.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -16,7 +16,7 @@
 
     <PackageReference Include="Selenium.WebDriver" Version="4.18.1" />
     
-    <PackageReference Include="Selema" Version="3.2.0" />
+    <PackageReference Include="Selema" Version="3.2.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -16,7 +16,7 @@
 
     <PackageReference Include="Selenium.WebDriver" Version="4.18.1" />
 
-    <PackageReference Include="Selema" Version="3.2.0" />
+    <PackageReference Include="Selema" Version="3.2.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump javiertuya/branch-snapshots-action from 1.2.1 to 1.2.2](https://github.com/javiertuya/selema/pull/547)
- [Bump Selema from 3.2.0 to 3.2.1 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/546)
- [Bump Selema from 3.2.0 to 3.2.1 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/545)
- [Bump io.github.javiertuya:selema from 3.2.0 to 3.2.1 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/544)
- [Bump io.github.javiertuya:selema from 3.2.0 to 3.2.1 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/543)