### PR TITLE
Combined dependency updates (2024-03-30)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -276,7 +276,7 @@
                     <plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.2.0</version>
+						<version>3.2.2</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -108,7 +108,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.12.1</version>
+				<version>3.13.0</version>
 				<configuration>
 					<source>11</source>
 					<target>11</target>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -99,7 +99,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.15.1</version>
+			<version>2.16.0</version>
 		</dependency>
 	</dependencies>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.18.1</version>
+			<version>4.19.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -62,7 +62,7 @@
 
     <PackageReference Include="WebDriverManager" Version="2.17.2" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.18.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.19.0" />
   </ItemGroup>
 
 </Project>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -50,7 +50,7 @@
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.59" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.60" />
 
     <PackageReference Include="NLog" Version="5.2.8" />
 

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.18.1</version>
+			<version>4.19.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.18.1</version>
+			<version>4.19.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.18.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.19.0" />
     
     <PackageReference Include="Selema" Version="3.2.1" />
   </ItemGroup>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.18.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.19.0" />
 
     <PackageReference Include="Selema" Version="3.2.1" />
   </ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump Selenium.WebDriver from 4.18.1 to 4.19.0 in /net/SelemaTest](https://github.com/javiertuya/selema/pull/565)
- [Bump HtmlAgilityPack from 1.11.59 to 1.11.60 in /net/SelemaTest](https://github.com/javiertuya/selema/pull/564)
- [Bump Selenium.WebDriver from 4.18.1 to 4.19.0 in /net/Selema](https://github.com/javiertuya/selema/pull/563)
- [Bump HtmlAgilityPack from 1.11.59 to 1.11.60 in /net/Selema](https://github.com/javiertuya/selema/pull/562)
- [Bump Selenium.WebDriver from 4.18.1 to 4.19.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/561)
- [Bump org.seleniumhq.selenium:selenium-java from 4.18.1 to 4.19.0 in /java](https://github.com/javiertuya/selema/pull/560)
- [Bump org.seleniumhq.selenium:selenium-java from 4.18.1 to 4.19.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/559)
- [Bump commons-io:commons-io from 2.15.1 to 2.16.0 in /java](https://github.com/javiertuya/selema/pull/558)
- [Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.0 to 3.2.2 in /java](https://github.com/javiertuya/selema/pull/557)
- [Bump org.seleniumhq.selenium:selenium-java from 4.18.1 to 4.19.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/556)
- [Bump Selenium.WebDriver from 4.18.1 to 4.19.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/555)
- [Bump org.apache.maven.plugins:maven-compiler-plugin from 3.12.1 to 3.13.0 in /java](https://github.com/javiertuya/selema/pull/554)