### PR TITLE
Combined dependency updates (2024-04-05)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -217,7 +217,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>3.3.0</version>
+				<version>3.3.1</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.19.0</version>
+			<version>4.19.1</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -70,7 +70,7 @@
 		<dependency>
 			<groupId>io.github.bonigarcia</groupId>
 			<artifactId>webdrivermanager</artifactId>
-			<version>5.7.0</version>
+			<version>5.8.0</version>
 		</dependency>
 
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -136,7 +136,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.11</version>
+				<version>0.8.12</version>
 				<executions>
 					<execution>
 						<id>pre-unit-test</id>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -46,7 +46,7 @@
     <!-- required only for selenium 3
     <PackageReference Include="Microsoft.Edge.SeleniumTools" Version="3.141.2" />
     -->
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
 
     <PackageReference Include="NUnit" Version="4.0.0" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
 

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.19.0</version>
+			<version>4.19.1</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.19.0</version>
+			<version>4.19.1</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
 
     <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
 

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.19.0" />
     


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump MSTest.TestFramework from 3.2.2 to 3.3.1 in /net/Selema](https://github.com/javiertuya/selema/pull/577)
- [Bump org.seleniumhq.selenium:selenium-java from 4.19.0 to 4.19.1 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/576)
- [Bump org.seleniumhq.selenium:selenium-java from 4.19.0 to 4.19.1 in /java](https://github.com/javiertuya/selema/pull/575)
- [Bump org.apache.maven.plugins:maven-source-plugin from 3.3.0 to 3.3.1 in /java](https://github.com/javiertuya/selema/pull/574)
- [Bump org.jacoco:jacoco-maven-plugin from 0.8.11 to 0.8.12 in /java](https://github.com/javiertuya/selema/pull/573)
- [Bump io.github.bonigarcia:webdrivermanager from 5.7.0 to 5.8.0 in /java](https://github.com/javiertuya/selema/pull/572)
- [Bump MSTest.TestFramework from 3.2.2 to 3.3.1 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/571)
- [Bump MSTest.TestAdapter from 3.2.2 to 3.3.1 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/570)
- [Bump org.seleniumhq.selenium:selenium-java from 4.19.0 to 4.19.1 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/569)
- [Bump MSTest.TestFramework from 3.2.2 to 3.3.1 in /net/SelemaTest](https://github.com/javiertuya/selema/pull/568)
- [Bump MSTest.TestAdapter from 3.2.2 to 3.3.1 in /net/SelemaTest](https://github.com/javiertuya/selema/pull/567)