### PR TITLE
Combined dependency updates (2024-04-13)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -99,7 +99,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.16.0</version>
+			<version>2.16.1</version>
 		</dependency>
 	</dependencies>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -276,7 +276,7 @@
                     <plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.2.2</version>
+						<version>3.2.3</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
 
-    <PackageReference Include="NUnit" Version="4.0.0" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump commons-io:commons-io from 2.16.0 to 2.16.1 in /java](https://github.com/javiertuya/selema/pull/581)
- [Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.2 to 3.2.3 in /java](https://github.com/javiertuya/selema/pull/580)
- [Bump NUnit from 4.0.0 to 4.1.0 in /net/SelemaTest](https://github.com/javiertuya/selema/pull/579)