### PR TITLE
Combined dependency updates (2024-05-05)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,7 @@ jobs:
       run:
         working-directory: java
     steps:
-      - uses: javiertuya/branch-snapshots-action@v1.2.2
+      - uses: javiertuya/branch-snapshots-action@v1.2.3
         with: 
           token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: java

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -50,7 +50,7 @@
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.60" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.61" />
 
     <PackageReference Include="NLog" Version="5.2.8" />
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -52,7 +52,7 @@
 
     <PackageReference Include="HtmlAgilityPack" Version="1.11.60" />
 
-    <PackageReference Include="NLog" Version="5.2.8" />
+    <PackageReference Include="NLog" Version="5.3.2" />
 
     <PackageReference Include="NUnit" Version="3.14.0" />
 

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.2.1</version>
+			<version>3.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.2.1</version>
+			<version>3.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -16,7 +16,7 @@
 
     <PackageReference Include="Selenium.WebDriver" Version="4.20.0" />
     
-    <PackageReference Include="Selema" Version="3.2.1" />
+    <PackageReference Include="Selema" Version="3.2.2" />
   </ItemGroup>
 
 </Project>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -16,7 +16,7 @@
 
     <PackageReference Include="Selenium.WebDriver" Version="4.20.0" />
 
-    <PackageReference Include="Selema" Version="3.2.1" />
+    <PackageReference Include="Selema" Version="3.2.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump javiertuya/branch-snapshots-action from 1.2.2 to 1.2.3](https://github.com/javiertuya/selema/pull/600)
- [Bump Selema from 3.2.1 to 3.2.2 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/599)
- [Bump io.github.javiertuya:selema from 3.2.1 to 3.2.2 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/598)
- [Bump HtmlAgilityPack from 1.11.60 to 1.11.61 in /net/Selema](https://github.com/javiertuya/selema/pull/597)
- [Bump NLog from 5.2.8 to 5.3.2 in /net/Selema](https://github.com/javiertuya/selema/pull/596)
- [Bump io.github.javiertuya:selema from 3.2.1 to 3.2.2 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/595)
- [Bump Selema from 3.2.1 to 3.2.2 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/594)