### PR TITLE
Combined dependency updates (2024-05-18)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.20.0</version>
+			<version>4.21.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -62,7 +62,7 @@
 
     <PackageReference Include="WebDriverManager" Version="2.17.2" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.20.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.21.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.20.0</version>
+			<version>4.21.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.20.0</version>
+			<version>4.21.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.20.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.21.0" />
     
     <PackageReference Include="Selema" Version="3.2.2" />
   </ItemGroup>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.20.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.21.0" />
 
     <PackageReference Include="Selema" Version="3.2.2" />
   </ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump Selenium.WebDriver from 4.20.0 to 4.21.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/607)
- [Bump org.seleniumhq.selenium:selenium-java from 4.20.0 to 4.21.0 in /java](https://github.com/javiertuya/selema/pull/606)
- [Bump org.seleniumhq.selenium:selenium-java from 4.20.0 to 4.21.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/605)
- [Bump Selenium.WebDriver from 4.20.0 to 4.21.0 in /net/Selema](https://github.com/javiertuya/selema/pull/604)
- [Bump org.seleniumhq.selenium:selenium-java from 4.20.0 to 4.21.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/603)
- [Bump Selenium.WebDriver from 4.20.0 to 4.21.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/602)