### PR TITLE
Combined dependency updates (2024-05-25)

### DIFF
--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -46,7 +46,7 @@
     <!-- required only for selenium 3
     <PackageReference Include="Microsoft.Edge.SeleniumTools" Version="3.141.2" />
     -->
-    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.4.0" />
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.4.0" />
 
     <PackageReference Include="NUnit" Version="4.1.0" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.4.0" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
 
     <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
 

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
 

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.4.0" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.21.0" />
     

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.4.0" />
 
     <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
 

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.21.0" />
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump MSTest.TestFramework from 3.3.1 to 3.4.0 in /net](https://github.com/javiertuya/selema/pull/619)
- [Bump MSTest.TestAdapter from 3.3.1 to 3.4.0 in /net](https://github.com/javiertuya/selema/pull/618)
- [Bump Microsoft.NET.Test.Sdk from 17.9.0 to 17.10.0 in /net](https://github.com/javiertuya/selema/pull/617)
- [Bump MSTest.TestAdapter from 3.3.1 to 3.4.0 in /net/SelemaTest](https://github.com/javiertuya/selema/pull/614)
- [Bump Microsoft.NET.Test.Sdk from 17.9.0 to 17.10.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/612)
- [Bump MSTest.TestFramework from 3.3.1 to 3.4.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/611)
- [Bump MSTest.TestAdapter from 3.3.1 to 3.4.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/610)
- [Bump Microsoft.NET.Test.Sdk from 17.9.0 to 17.10.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/609)