### PR TITLE
Combined dependency updates (2024-06-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
       #    skip_publishing: ${{ github.actor != 'javiertuya' }} #avoids failure on dependabot or other user PRs
       - name: Generate report checks1
         if: always()
-        uses: mikepenz/action-junit-report@v4.2.1
+        uses: mikepenz/action-junit-report@v4.2.2
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -265,7 +265,7 @@
 					<plugin>
 						<groupId>org.sonatype.plugins</groupId>
 						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<version>1.6.13</version>
+						<version>1.7.0</version>
 						<extensions>true</extensions>
 						<configuration>
 							<serverId>ossrh</serverId>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -46,7 +46,7 @@
     <!-- required only for selenium 3
     <PackageReference Include="Microsoft.Edge.SeleniumTools" Version="3.141.2" />
     -->
-    <PackageReference Include="MSTest.TestFramework" Version="3.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.4.0" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.4.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.4.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
 
     <PackageReference Include="NUnit" Version="4.1.0" />
 

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.4.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
 
     <PackageReference Include="MSTest.TestFramework" Version="3.4.0" />
 

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.4.0" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.21.0" />
     


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump MSTest.TestAdapter from 3.4.0 to 3.4.3 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/626)
- [Bump MSTest.TestFramework from 3.4.0 to 3.4.3 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/625)
- [Bump mikepenz/action-junit-report from 4.2.1 to 4.2.2](https://github.com/javiertuya/selema/pull/624)
- [Bump MSTest.TestFramework from 3.4.0 to 3.4.3 in /net](https://github.com/javiertuya/selema/pull/623)
- [Bump MSTest.TestAdapter from 3.4.0 to 3.4.3 in /net](https://github.com/javiertuya/selema/pull/622)
- [Bump org.sonatype.plugins:nexus-staging-maven-plugin from 1.6.13 to 1.7.0 in /java](https://github.com/javiertuya/selema/pull/621)