### PR TITLE
Combined dependency updates (2024-06-22)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
       #    skip_publishing: ${{ github.actor != 'javiertuya' }} #avoids failure on dependabot or other user PRs
       - name: Generate report checks1
         if: always()
-        uses: mikepenz/action-junit-report@v4.2.2
+        uses: mikepenz/action-junit-report@v4.3.0
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.21.0</version>
+			<version>4.22.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -60,7 +60,7 @@
 
     <PackageReference Include="VisualAssert" Version="2.4.1" />
 
-    <PackageReference Include="WebDriverManager" Version="2.17.2" />
+    <PackageReference Include="WebDriverManager" Version="2.17.3" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.21.0" />
   </ItemGroup>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -62,7 +62,7 @@
 
     <PackageReference Include="WebDriverManager" Version="2.17.2" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.21.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.22.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.21.0</version>
+			<version>4.22.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -47,7 +47,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.2.5</version>
+				<version>3.3.0</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.21.0</version>
+			<version>4.22.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.21.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.22.0" />
     
     <PackageReference Include="Selema" Version="3.2.2" />
   </ItemGroup>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.21.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.22.0" />
 
     <PackageReference Include="Selema" Version="3.2.2" />
   </ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.seleniumhq.selenium:selenium-java from 4.21.0 to 4.22.0 in /java](https://github.com/javiertuya/selema/pull/639)
- [Bump Selenium.WebDriver from 4.21.0 to 4.22.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/638)
- [Bump Selenium.WebDriver from 4.21.0 to 4.22.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/637)
- [Bump org.seleniumhq.selenium:selenium-java from 4.21.0 to 4.22.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/636)
- [Bump org.seleniumhq.selenium:selenium-java from 4.21.0 to 4.22.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/635)
- [Bump org.apache.maven.plugins:maven-surefire-plugin from 3.2.5 to 3.3.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/634)
- [Bump Selenium.WebDriver from 4.21.0 to 4.22.0 in /net](https://github.com/javiertuya/selema/pull/633)
- [Bump WebDriverManager from 2.17.2 to 2.17.3 in /net](https://github.com/javiertuya/selema/pull/632)
- [Bump mikepenz/action-junit-report from 4.2.2 to 4.3.0](https://github.com/javiertuya/selema/pull/631)