### PR TITLE
Combined dependency updates (2024-06-28)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
       #    skip_publishing: ${{ github.actor != 'javiertuya' }} #avoids failure on dependabot or other user PRs
       - name: Generate report checks1
         if: always()
-        uses: mikepenz/action-junit-report@v4.3.0
+        uses: mikepenz/action-junit-report@v4.3.1
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: javiertuya/sonarqube-action@v1.3.1
+      - uses: javiertuya/sonarqube-action@v1.3.2
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 
-		<junit-jupiter.version>5.10.2</junit-jupiter.version>
+		<junit-jupiter.version>5.10.3</junit-jupiter.version>
 
 		<junit.version>4.13.2</junit.version>
 		

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -70,7 +70,7 @@
 		<dependency>
 			<groupId>io.github.bonigarcia</groupId>
 			<artifactId>webdrivermanager</artifactId>
-			<version>5.8.0</version>
+			<version>5.9.1</version>
 		</dependency>
 
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -76,7 +76,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>portable-java</artifactId>
-			<version>2.2.1</version>
+			<version>2.2.3</version>
 		</dependency>
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -81,7 +81,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>visual-assert</artifactId>
-			<version>2.4.1</version>
+			<version>2.4.2</version>
 		</dependency>
 
 		<dependency>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -56,7 +56,7 @@
 
     <PackageReference Include="NUnit" Version="3.14.0" />
 
-    <PackageReference Include="PortableCs" Version="2.2.2" />
+    <PackageReference Include="PortableCs" Version="2.2.3" />
 
     <PackageReference Include="VisualAssert" Version="2.4.1" />
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -58,7 +58,7 @@
 
     <PackageReference Include="PortableCs" Version="2.2.2" />
 
-    <PackageReference Include="VisualAssert" Version="2.4.1" />
+    <PackageReference Include="VisualAssert" Version="2.4.2" />
 
     <PackageReference Include="WebDriverManager" Version="2.17.3" />
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -60,7 +60,7 @@
 
     <PackageReference Include="VisualAssert" Version="2.4.1" />
 
-    <PackageReference Include="WebDriverManager" Version="2.17.3" />
+    <PackageReference Include="WebDriverManager" Version="2.17.4" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.22.0" />
   </ItemGroup>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.10.2</version>
+			<version>5.10.3</version>
 		</dependency>
 		<dependency>
 		   <groupId>io.github.artsok</groupId>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump VisualAssert from 2.4.1 to 2.4.2 in /net](https://github.com/javiertuya/selema/pull/651)
- [Bump PortableCs from 2.2.2 to 2.2.3 in /net](https://github.com/javiertuya/selema/pull/650)
- [Bump io.github.javiertuya:visual-assert from 2.4.1 to 2.4.2 in /java](https://github.com/javiertuya/selema/pull/649)
- [Bump io.github.javiertuya:portable-java from 2.2.1 to 2.2.3 in /java](https://github.com/javiertuya/selema/pull/648)
- [Bump WebDriverManager from 2.17.3 to 2.17.4 in /net](https://github.com/javiertuya/selema/pull/647)
- [Bump junit-jupiter.version from 5.10.2 to 5.10.3 in /java](https://github.com/javiertuya/selema/pull/646)
- [Bump io.github.bonigarcia:webdrivermanager from 5.8.0 to 5.9.1 in /java](https://github.com/javiertuya/selema/pull/645)
- [Bump org.junit.jupiter:junit-jupiter-engine from 5.10.2 to 5.10.3 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/644)
- [Bump mikepenz/action-junit-report from 4.3.0 to 4.3.1](https://github.com/javiertuya/selema/pull/643)
- [Bump javiertuya/sonarqube-action from 1.3.1 to 1.3.2](https://github.com/javiertuya/selema/pull/642)