### PR TITLE
Combined dependency updates (2024-07-06)

### DIFF
--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.2.2</version>
+			<version>3.2.3</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.2.2</version>
+			<version>3.2.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -16,7 +16,7 @@
 
     <PackageReference Include="Selenium.WebDriver" Version="4.22.0" />
     
-    <PackageReference Include="Selema" Version="3.2.2" />
+    <PackageReference Include="Selema" Version="3.2.3" />
   </ItemGroup>
 
 </Project>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -16,7 +16,7 @@
 
     <PackageReference Include="Selenium.WebDriver" Version="4.22.0" />
 
-    <PackageReference Include="Selema" Version="3.2.2" />
+    <PackageReference Include="Selema" Version="3.2.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump Selema from 3.2.2 to 3.2.3 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/658)
- [Bump Selema from 3.2.2 to 3.2.3 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/656)
- [Bump io.github.javiertuya:selema from 3.2.2 to 3.2.3 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/655)
- [Bump io.github.javiertuya:selema from 3.2.2 to 3.2.3 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/654)