### PR TITLE
Combined dependency updates (2024-07-13)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       packages: write 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4.0.0
+      - uses: actions/setup-dotnet@v4.0.1
         with:
             dotnet-version: '6.0.x'
       - name: Pack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
 
       - if: always()
         name: Publish test report files
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: "test-report-${{ matrix.platform }}-${{ matrix.mode }}-files"
           path: |
@@ -121,7 +121,7 @@ jobs:
             !**/selenoid*.mp4
       - name: JAVA - Reports for Sonar
         if: ${{ always() && matrix.platform=='java' }}
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: "sonar-${{ matrix.platform }}-${{ matrix.mode }}"
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: '11'
           cache: 'maven'
       - if: ${{ matrix.platform=='net' }}
-        uses: actions/setup-dotnet@v4.0.0
+        uses: actions/setup-dotnet@v4.0.1
         with:
             dotnet-version: '6.0.x'
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -25,7 +25,7 @@
 
 		<junit.version>4.13.2</junit.version>
 		
-		<surefire.version>3.3.0</surefire.version>
+		<surefire.version>3.3.1</surefire.version>
 		
 		<slf4j.version>2.0.13</slf4j.version>
 	</properties>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -47,7 +47,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.3.0</version>
+				<version>3.3.1</version>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.apache.maven.plugins:maven-surefire-plugin from 3.3.0 to 3.3.1 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/663)
- [Bump surefire.version from 3.3.0 to 3.3.1 in /java](https://github.com/javiertuya/selema/pull/662)
- [Bump actions/setup-dotnet from 4.0.0 to 4.0.1](https://github.com/javiertuya/selema/pull/661)
- [Bump actions/upload-artifact from 4.3.3 to 4.3.4](https://github.com/javiertuya/selema/pull/660)