### PR TITLE
Combined dependency updates (2024-07-20)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: javiertuya/sonarqube-action@v1.3.2
+      - uses: javiertuya/sonarqube-action@v1.4.0
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -46,7 +46,7 @@
     <!-- required only for selenium 3
     <PackageReference Include="Microsoft.Edge.SeleniumTools" Version="3.141.2" />
     -->
-    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
 
     <PackageReference Include="NUnit" Version="4.1.0" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
 

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
 
     <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
 

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.22.0" />
     


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump MSTest.TestFramework from 3.4.3 to 3.5.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/669)
- [Bump MSTest.TestAdapter from 3.4.3 to 3.5.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/668)
- [Bump javiertuya/sonarqube-action from 1.3.2 to 1.4.0](https://github.com/javiertuya/selema/pull/667)
- [Bump MSTest.TestAdapter from 3.4.3 to 3.5.0 in /net](https://github.com/javiertuya/selema/pull/666)
- [Bump MSTest.TestFramework from 3.4.3 to 3.5.0 in /net](https://github.com/javiertuya/selema/pull/665)