### PR TITLE
Combined dependency updates (2024-08-03)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -70,7 +70,7 @@
 		<dependency>
 			<groupId>io.github.bonigarcia</groupId>
 			<artifactId>webdrivermanager</artifactId>
-			<version>5.9.1</version>
+			<version>5.9.2</version>
 		</dependency>
 
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -230,7 +230,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.7.0</version>
+				<version>3.8.0</version>
 				<configuration>
 					<quiet>true</quiet>
 					<doclint>none</doclint>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -50,7 +50,7 @@
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.61" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.62" />
 
     <PackageReference Include="NLog" Version="5.3.2" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -16,7 +16,7 @@
 
     <PackageReference Include="NUnit" Version="4.1.0" />
 
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.14.0" />
 
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump HtmlAgilityPack from 1.11.61 to 1.11.62 in /net](https://github.com/javiertuya/selema/pull/679)
- [Bump NUnit3TestAdapter from 4.5.0 to 4.6.0 in /net](https://github.com/javiertuya/selema/pull/678)
- [Bump io.github.bonigarcia:webdrivermanager from 5.9.1 to 5.9.2 in /java](https://github.com/javiertuya/selema/pull/677)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.7.0 to 3.8.0 in /java](https://github.com/javiertuya/selema/pull/676)
- [Bump NUnit3TestAdapter from 4.5.0 to 4.6.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/675)