### PR TITLE
Combined dependency updates (2024-08-14)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,7 @@ jobs:
 
       - if: always()
         name: Publish test report files
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@v4.3.6
         with:
           name: "test-report-${{ matrix.platform }}-${{ matrix.mode }}-files"
           path: |
@@ -124,7 +124,7 @@ jobs:
             !**/selenoid*.mp4
       - name: JAVA - Reports for Sonar
         if: ${{ always() && matrix.platform=='java' }}
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@v4.3.6
         with:
           name: "sonar-${{ matrix.platform }}-${{ matrix.mode }}"
           path: |

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -76,7 +76,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>portable-java</artifactId>
-			<version>2.2.3</version>
+			<version>2.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.23.0</version>
+			<version>4.23.1</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -81,7 +81,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>visual-assert</artifactId>
-			<version>2.4.2</version>
+			<version>2.5.0</version>
 		</dependency>
 
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -27,7 +27,7 @@
 		
 		<surefire.version>3.3.1</surefire.version>
 		
-		<slf4j.version>2.0.13</slf4j.version>
+		<slf4j.version>2.0.16</slf4j.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -276,7 +276,7 @@
                     <plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.2.4</version>
+						<version>3.2.5</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -56,7 +56,7 @@
 
     <PackageReference Include="NUnit" Version="3.14.0" />
 
-    <PackageReference Include="PortableCs" Version="2.2.3" />
+    <PackageReference Include="PortableCs" Version="2.3.0" />
 
     <PackageReference Include="VisualAssert" Version="2.4.2" />
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -52,7 +52,7 @@
 
     <PackageReference Include="HtmlAgilityPack" Version="1.11.62" />
 
-    <PackageReference Include="NLog" Version="5.3.2" />
+    <PackageReference Include="NLog" Version="5.3.3" />
 
     <PackageReference Include="NUnit" Version="3.14.0" />
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -58,7 +58,7 @@
 
     <PackageReference Include="PortableCs" Version="2.2.3" />
 
-    <PackageReference Include="VisualAssert" Version="2.4.2" />
+    <PackageReference Include="VisualAssert" Version="2.5.0" />
 
     <PackageReference Include="WebDriverManager" Version="2.17.4" />
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -46,7 +46,7 @@
     <!-- required only for selenium 3
     <PackageReference Include="Microsoft.Edge.SeleniumTools" Version="3.141.2" />
     -->
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.2" />
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.5.2" />
 
     <PackageReference Include="NUnit" Version="4.1.0" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.2" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
 

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.22.0</version>
+			<version>4.23.1</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.22.0</version>
+			<version>4.23.1</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.2" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.22.0" />
     

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.5.2" />
 
     <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump VisualAssert from 2.4.2 to 2.5.0 in /net](https://github.com/javiertuya/selema/pull/700)
- [Bump MSTest.TestAdapter from 3.5.0 to 3.5.2 in /net](https://github.com/javiertuya/selema/pull/699)
- [Bump MSTest.TestFramework from 3.5.0 to 3.5.2 in /net](https://github.com/javiertuya/selema/pull/698)
- [Bump NLog from 5.3.2 to 5.3.3 in /net](https://github.com/javiertuya/selema/pull/697)
- [Bump MSTest.TestFramework from 3.5.0 to 3.5.2 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/696)
- [Bump MSTest.TestAdapter from 3.5.0 to 3.5.2 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/695)
- [Bump org.seleniumhq.selenium:selenium-java from 4.22.0 to 4.23.1 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/694)
- [Bump org.seleniumhq.selenium:selenium-java from 4.22.0 to 4.23.1 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/693)
- [Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.4 to 3.2.5 in /java](https://github.com/javiertuya/selema/pull/692)
- [Bump io.github.javiertuya:visual-assert from 2.4.2 to 2.5.0 in /java](https://github.com/javiertuya/selema/pull/691)
- [Bump slf4j.version from 2.0.13 to 2.0.16 in /java](https://github.com/javiertuya/selema/pull/690)
- [Bump org.seleniumhq.selenium:selenium-java from 4.23.0 to 4.23.1 in /java](https://github.com/javiertuya/selema/pull/689)
- [Bump actions/upload-artifact from 4.3.4 to 4.3.6](https://github.com/javiertuya/selema/pull/687)
- [Bump PortableCs from 2.2.3 to 2.3.0 in /net](https://github.com/javiertuya/selema/pull/686)
- [Bump io.github.javiertuya:portable-java from 2.2.3 to 2.3.0 in /java](https://github.com/javiertuya/selema/pull/683)