### PR TITLE
Combined dependency updates (2024-08-25)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 
-		<junit-jupiter.version>5.10.3</junit-jupiter.version>
+		<junit-jupiter.version>5.11.0</junit-jupiter.version>
 
 		<junit.version>4.13.2</junit.version>
 		

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -25,7 +25,7 @@
 
 		<junit.version>4.13.2</junit.version>
 		
-		<surefire.version>3.3.1</surefire.version>
+		<surefire.version>3.4.0</surefire.version>
 		
 		<slf4j.version>2.0.16</slf4j.version>
 	</properties>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -50,7 +50,7 @@
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.62" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.64" />
 
     <PackageReference Include="NLog" Version="5.3.3" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
 
     <PackageReference Include="MSTest.TestFramework" Version="3.5.2" />
 

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.10.3</version>
+			<version>5.11.0</version>
 		</dependency>
 		<dependency>
 		   <groupId>io.github.artsok</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -47,7 +47,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.3.1</version>
+				<version>3.4.0</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.5.2" />
 

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.22.0" />
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.apache.maven.plugins:maven-surefire-plugin from 3.3.1 to 3.4.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/711)
- [Bump surefire.version from 3.3.1 to 3.4.0 in /java](https://github.com/javiertuya/selema/pull/710)
- [Bump Microsoft.NET.Test.Sdk from 17.10.0 to 17.11.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/709)
- [Bump Microsoft.NET.Test.Sdk from 17.10.0 to 17.11.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/707)
- [Bump HtmlAgilityPack from 1.11.62 to 1.11.64 in /net](https://github.com/javiertuya/selema/pull/706)
- [Bump Microsoft.NET.Test.Sdk from 17.10.0 to 17.11.0 in /net](https://github.com/javiertuya/selema/pull/705)
- [Bump org.junit.jupiter:junit-jupiter-engine from 5.10.3 to 5.11.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/704)
- [Bump junit-jupiter.version from 5.10.3 to 5.11.0 in /java](https://github.com/javiertuya/selema/pull/703)