### PR TITLE
Combined dependency updates (2024-09-02)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -205,7 +205,7 @@
 					<dependency>
 						<groupId>org.apache.ant</groupId>
 						<artifactId>ant-junit</artifactId>
-						<version>1.10.14</version>
+						<version>1.10.15</version>
 					</dependency>
 					<dependency>
 						<groupId>org.apache.ant</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -25,7 +25,7 @@
 
 		<junit.version>4.13.2</junit.version>
 		
-		<surefire.version>3.4.0</surefire.version>
+		<surefire.version>3.5.0</surefire.version>
 		
 		<slf4j.version>2.0.16</slf4j.version>
 	</properties>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.23.1</version>
+			<version>4.24.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -230,7 +230,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.8.0</version>
+				<version>3.10.0</version>
 				<configuration>
 					<quiet>true</quiet>
 					<doclint>none</doclint>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -62,7 +62,7 @@
 
     <PackageReference Include="WebDriverManager" Version="2.17.4" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.23.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.24.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.23.1</version>
+			<version>4.24.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -47,7 +47,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.4.0</version>
+				<version>3.5.0</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.23.1</version>
+			<version>4.24.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.5.2" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.22.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.24.0" />
     
     <PackageReference Include="Selema" Version="3.2.3" />
   </ItemGroup>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.22.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.24.0" />
 
     <PackageReference Include="Selema" Version="3.2.3" />
   </ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump Selenium.WebDriver from 4.22.0 to 4.24.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/722)
- [Bump Selenium.WebDriver from 4.22.0 to 4.24.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/721)
- [Bump org.seleniumhq.selenium:selenium-java from 4.23.1 to 4.24.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/720)
- [Bump org.apache.maven.plugins:maven-surefire-plugin from 3.4.0 to 3.5.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/719)
- [Bump org.seleniumhq.selenium:selenium-java from 4.23.1 to 4.24.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/718)
- [Bump org.seleniumhq.selenium:selenium-java from 4.23.1 to 4.24.0 in /java](https://github.com/javiertuya/selema/pull/717)
- [Bump org.apache.ant:ant-junit from 1.10.14 to 1.10.15 in /java](https://github.com/javiertuya/selema/pull/716)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.8.0 to 3.10.0 in /java](https://github.com/javiertuya/selema/pull/715)
- [Bump surefire.version from 3.4.0 to 3.5.0 in /java](https://github.com/javiertuya/selema/pull/714)
- [Bump Selenium.WebDriver from 4.23.0 to 4.24.0 in /net](https://github.com/javiertuya/selema/pull/713)