### PR TITLE
Combined dependency updates (2024-09-28)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 
-		<junit-jupiter.version>5.11.0</junit-jupiter.version>
+		<junit-jupiter.version>5.11.1</junit-jupiter.version>
 
 		<junit.version>4.13.2</junit.version>
 		

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -99,7 +99,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.16.1</version>
+			<version>2.17.0</version>
 		</dependency>
 	</dependencies>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -276,7 +276,7 @@
                     <plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.2.5</version>
+						<version>3.2.6</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.24.0</version>
+			<version>4.25.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -50,7 +50,7 @@
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.65" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.66" />
 
     <PackageReference Include="NLog" Version="5.3.4" />
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -62,7 +62,7 @@
 
     <PackageReference Include="WebDriverManager" Version="2.17.4" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.24.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.25.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.24.0</version>
+			<version>4.25.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.24.0</version>
+			<version>4.25.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.11.0</version>
+			<version>5.11.1</version>
 		</dependency>
 		<dependency>
 		   <groupId>io.github.artsok</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.6.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.24.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.25.0" />
     
     <PackageReference Include="Selema" Version="3.2.3" />
   </ItemGroup>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.24.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.25.0" />
 
     <PackageReference Include="Selema" Version="3.2.3" />
   </ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump Selenium.WebDriver from 4.24.0 to 4.25.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/746)
- [Bump Selenium.WebDriver from 4.24.0 to 4.25.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/745)
- [Bump HtmlAgilityPack from 1.11.65 to 1.11.66 in /net](https://github.com/javiertuya/selema/pull/744)
- [Bump Selenium.WebDriver from 4.24.0 to 4.25.0 in /net](https://github.com/javiertuya/selema/pull/743)
- [Bump org.seleniumhq.selenium:selenium-java from 4.24.0 to 4.25.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/742)
- [Bump org.junit.jupiter:junit-jupiter-engine from 5.11.0 to 5.11.1 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/741)
- [Bump org.seleniumhq.selenium:selenium-java from 4.24.0 to 4.25.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/740)
- [Bump org.seleniumhq.selenium:selenium-java from 4.24.0 to 4.25.0 in /java](https://github.com/javiertuya/selema/pull/739)
- [Bump junit-jupiter.version from 5.11.0 to 5.11.1 in /java](https://github.com/javiertuya/selema/pull/738)
- [Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.5 to 3.2.6 in /java](https://github.com/javiertuya/selema/pull/737)
- [Bump commons-io:commons-io from 2.16.1 to 2.17.0 in /java](https://github.com/javiertuya/selema/pull/736)