### PR TITLE
Combined dependency updates (2024-10-25)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       packages: write 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4.0.1
+      - uses: actions/setup-dotnet@v4.1.0
         with:
             dotnet-version: '6.0.x'
       - name: Pack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           java-version: '11'
           cache: 'maven'
       - if: ${{ matrix.platform=='net' }}
-        uses: actions/setup-dotnet@v4.0.1
+        uses: actions/setup-dotnet@v4.1.0
         with:
             dotnet-version: '6.0.x'
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -81,7 +81,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>visual-assert</artifactId>
-			<version>2.5.0</version>
+			<version>2.5.1</version>
 		</dependency>
 
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 
-		<junit-jupiter.version>5.11.2</junit-jupiter.version>
+		<junit-jupiter.version>5.11.3</junit-jupiter.version>
 
 		<junit.version>4.13.2</junit.version>
 		

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -58,7 +58,7 @@
 
     <PackageReference Include="PortableCs" Version="2.3.0" />
 
-    <PackageReference Include="VisualAssert" Version="2.5.0" />
+    <PackageReference Include="VisualAssert" Version="2.5.1" />
 
     <PackageReference Include="WebDriverManager" Version="2.17.4" />
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -50,7 +50,7 @@
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.67" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.69" />
 
     <PackageReference Include="NLog" Version="5.3.4" />
 

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.11.2</version>
+			<version>5.11.3</version>
 		</dependency>
 		<dependency>
 		   <groupId>io.github.artsok</groupId>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.junit.jupiter:junit-jupiter-engine from 5.11.2 to 5.11.3 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/765)
- [Bump io.github.javiertuya:visual-assert from 2.5.0 to 2.5.1 in /java](https://github.com/javiertuya/selema/pull/764)
- [Bump junit-jupiter.version from 5.11.2 to 5.11.3 in /java](https://github.com/javiertuya/selema/pull/763)
- [Bump actions/setup-dotnet from 4.0.1 to 4.1.0](https://github.com/javiertuya/selema/pull/762)
- [Bump VisualAssert from 2.5.0 to 2.5.1 in /net](https://github.com/javiertuya/selema/pull/761)
- [Bump HtmlAgilityPack from 1.11.67 to 1.11.69 in /net](https://github.com/javiertuya/selema/pull/760)