### PR TITLE
Combined dependency updates (2024-11-02)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       #https://stackoverflow.com/questions/61096521/how-to-use-gpg-key-in-github-actions
       #It requires export the private key with the armor option: gpg --output private.pgm --armor --export-secret-key <email>
       - name: Import GPG Key 
-        uses: crazy-max/ghaction-import-gpg@v6.1.0
+        uses: crazy-max/ghaction-import-gpg@v6.2.0
         with:
           gpg_private_key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.25.0</version>
+			<version>4.26.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -50,7 +50,7 @@
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.69" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.70" />
 
     <PackageReference Include="NLog" Version="5.3.4" />
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -62,7 +62,7 @@
 
     <PackageReference Include="WebDriverManager" Version="2.17.4" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.25.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.26.1" />
   </ItemGroup>
 
 </Project>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -46,7 +46,7 @@
     <!-- required only for selenium 3
     <PackageReference Include="Microsoft.Edge.SeleniumTools" Version="3.141.2" />
     -->
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.2" />
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.2" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.2" />
 
     <PackageReference Include="NUnit" Version="4.1.0" />
 

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.25.0</version>
+			<version>4.26.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.25.0</version>
+			<version>4.26.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.2" />
 
     <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
 

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.2" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.25.0" />
     

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.25.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.26.1" />
     
     <PackageReference Include="Selema" Version="3.2.3" />
   </ItemGroup>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.25.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.26.1" />
 
     <PackageReference Include="Selema" Version="3.2.3" />
   </ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump crazy-max/ghaction-import-gpg from 6.1.0 to 6.2.0](https://github.com/javiertuya/selema/pull/777)
- [Bump org.seleniumhq.selenium:selenium-java from 4.25.0 to 4.26.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/776)
- [Bump org.seleniumhq.selenium:selenium-java from 4.25.0 to 4.26.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/775)
- [Bump org.seleniumhq.selenium:selenium-java from 4.25.0 to 4.26.0 in /java](https://github.com/javiertuya/selema/pull/774)
- [Bump Selenium.WebDriver from 4.25.0 to 4.26.1 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/773)
- [Bump MSTest.TestFramework from 3.6.1 to 3.6.2 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/772)
- [Bump MSTest.TestAdapter from 3.6.1 to 3.6.2 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/771)
- [Bump Selenium.WebDriver from 4.25.0 to 4.26.1 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/770)
- [Bump Selenium.WebDriver from 4.25.0 to 4.26.1 in /net](https://github.com/javiertuya/selema/pull/769)
- [Bump HtmlAgilityPack from 1.11.69 to 1.11.70 in /net](https://github.com/javiertuya/selema/pull/768)
- [Bump the mstest group in /net with 2 updates](https://github.com/javiertuya/selema/pull/767)