### PR TITLE
Combined dependency updates (2024-11-23)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
       #    skip_publishing: ${{ github.actor != 'javiertuya' }} #avoids failure on dependabot or other user PRs
       - name: Generate report checks1
         if: always()
-        uses: mikepenz/action-junit-report@v4.3.1
+        uses: mikepenz/action-junit-report@v5.0.0
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -25,7 +25,7 @@
 
 		<junit.version>4.13.2</junit.version>
 		
-		<surefire.version>3.5.1</surefire.version>
+		<surefire.version>3.5.2</surefire.version>
 		
 		<slf4j.version>2.0.16</slf4j.version>
 	</properties>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -230,7 +230,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.10.1</version>
+				<version>3.11.1</version>
 				<configuration>
 					<quiet>true</quiet>
 					<doclint>none</doclint>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -99,7 +99,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.17.0</version>
+			<version>2.18.0</version>
 		</dependency>
 	</dependencies>
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -50,7 +50,7 @@
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.70" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.71" />
 
     <PackageReference Include="NLog" Version="5.3.4" />
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -46,7 +46,7 @@
     <!-- required only for selenium 3
     <PackageReference Include="Microsoft.Edge.SeleniumTools" Version="3.141.2" />
     -->
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
 
     <PackageReference Include="NUnit" Version="4.1.0" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 
     <PackageReference Include="MSTest.TestFramework" Version="3.6.2" />
 

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -47,7 +47,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.5.1</version>
+				<version>3.5.2</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.2" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.26.1" />
     

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
 
     <PackageReference Include="MSTest.TestFramework" Version="3.6.2" />
 

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.2" />
 

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.26.1" />
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump mikepenz/action-junit-report from 4.3.1 to 5.0.0](https://github.com/javiertuya/selema/pull/791)
- [Bump the mstest group in /net with 2 updates](https://github.com/javiertuya/selema/pull/785)
- [Bump Microsoft.NET.Test.Sdk from 17.11.1 to 17.12.0 in /net](https://github.com/javiertuya/selema/pull/790)
- [Bump Microsoft.NET.Test.Sdk from 17.11.1 to 17.12.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/789)
- [Bump Microsoft.NET.Test.Sdk from 17.11.1 to 17.12.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/788)
- [Bump commons-io:commons-io from 2.17.0 to 2.18.0 in /java](https://github.com/javiertuya/selema/pull/787)
- [Bump HtmlAgilityPack from 1.11.70 to 1.11.71 in /net](https://github.com/javiertuya/selema/pull/786)
- [Bump MSTest.TestFramework from 3.6.2 to 3.6.3 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/784)
- [Bump MSTest.TestAdapter from 3.6.2 to 3.6.3 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/783)
- [Bump org.apache.maven.plugins:maven-surefire-plugin from 3.5.1 to 3.5.2 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/782)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.10.1 to 3.11.1 in /java](https://github.com/javiertuya/selema/pull/781)
- [Bump surefire.version from 3.5.1 to 3.5.2 in /java](https://github.com/javiertuya/selema/pull/780)