### PR TITLE
Combined dependency updates (2024-12-03)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
       #    skip_publishing: ${{ github.actor != 'javiertuya' }} #avoids failure on dependabot or other user PRs
       - name: Generate report checks1
         if: always()
-        uses: mikepenz/action-junit-report@v5.0.0
+        uses: mikepenz/action-junit-report@v5.1.0
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.26.0</version>
+			<version>4.27.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.26.0</version>
+			<version>4.27.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.26.0</version>
+			<version>4.27.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.26.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.27.0" />
     
     <PackageReference Include="Selema" Version="3.2.3" />
   </ItemGroup>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.26.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.27.0" />
 
     <PackageReference Include="Selema" Version="3.2.3" />
   </ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump Selenium.WebDriver from 4.26.1 to 4.27.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/799)
- [Bump Selenium.WebDriver from 4.26.1 to 4.27.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/798)
- [Bump org.seleniumhq.selenium:selenium-java from 4.26.0 to 4.27.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/796)
- [Bump org.seleniumhq.selenium:selenium-java from 4.26.0 to 4.27.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/795)
- [Bump org.seleniumhq.selenium:selenium-java from 4.26.0 to 4.27.0 in /java](https://github.com/javiertuya/selema/pull/794)
- [Bump mikepenz/action-junit-report from 5.0.0 to 5.1.0](https://github.com/javiertuya/selema/pull/793)