### PR TITLE
Combined dependency updates (2024-12-06)

### DIFF
--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -46,7 +46,7 @@
     <!-- required only for selenium 3
     <PackageReference Include="Microsoft.Edge.SeleniumTools" Version="3.141.2" />
     -->
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.4" />
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.4" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.4" />
 
     <PackageReference Include="NUnit" Version="4.1.0" />
 

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.4" />
 
     <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
 

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.4" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.27.0" />
     


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump the mstest group in /net with 2 updates](https://github.com/javiertuya/selema/pull/806)
- [Bump MSTest.TestAdapter from 3.6.3 to 3.6.4 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/805)
- [Bump MSTest.TestFramework from 3.6.3 to 3.6.4 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/804)