### PR TITLE
Combined dependency updates (2025-02-03)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       packages: write 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4.2.0
+      - uses: actions/setup-dotnet@v4.3.0
         with:
             dotnet-version: '6.0.x'
       - name: Pack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           java-version: '11'
           cache: 'maven'
       - if: ${{ matrix.platform=='net' }}
-        uses: actions/setup-dotnet@v4.2.0
+        uses: actions/setup-dotnet@v4.3.0
         with:
             dotnet-version: '8.0.x'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
       #    skip_publishing: ${{ github.actor != 'javiertuya' }} #avoids failure on dependabot or other user PRs
       - name: Generate report checks1
         if: always()
-        uses: mikepenz/action-junit-report@v5.2.0
+        uses: mikepenz/action-junit-report@v5.3.0
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,7 @@ jobs:
 
       - if: always()
         name: Publish test report files
-        uses: actions/upload-artifact@v4.5.0
+        uses: actions/upload-artifact@v4.6.0
         with:
           name: "test-report-${{ matrix.platform }}-${{ matrix.mode }}-files"
           path: |
@@ -124,7 +124,7 @@ jobs:
             !**/selenoid*.mp4
       - name: JAVA - Reports for Sonar
         if: ${{ always() && matrix.platform=='java' }}
-        uses: actions/upload-artifact@v4.5.0
+        uses: actions/upload-artifact@v4.6.0
         with:
           name: "sonar-${{ matrix.platform }}-${{ matrix.mode }}"
           path: |

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.27.0</version>
+			<version>4.28.1</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -46,7 +46,7 @@
     <!-- required only for selenium 3
     <PackageReference Include="Microsoft.Edge.SeleniumTools" Version="3.141.2" />
     -->
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -62,7 +62,7 @@
 
     <PackageReference Include="WebDriverManager" Version="2.17.5" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.27.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.28.0" />
   </ItemGroup>
 
 </Project>

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.7.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
 
     <PackageReference Include="NUnit" Version="4.1.0" />
 

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.2.3</version>
+			<version>3.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.27.0</version>
+			<version>4.28.1</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.2.3</version>
+			<version>3.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.27.0</version>
+			<version>4.28.1</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.7.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.27.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.28.0" />
     
     <PackageReference Include="Selema" Version="3.2.3" />
   </ItemGroup>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.7.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.27.0" />
     

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.27.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.28.0" />
 
     <PackageReference Include="Selema" Version="3.2.3" />
   </ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.seleniumhq.selenium:selenium-java from 4.27.0 to 4.28.1 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/831)
- [Bump io.github.javiertuya:selema from 3.2.3 to 3.3.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/830)
- [Bump org.seleniumhq.selenium:selenium-java from 4.27.0 to 4.28.1 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/829)
- [Bump io.github.javiertuya:selema from 3.2.3 to 3.3.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/828)
- [Bump org.seleniumhq.selenium:selenium-java from 4.27.0 to 4.28.1 in /java](https://github.com/javiertuya/selema/pull/827)
- [Bump Selenium.WebDriver from 4.27.0 to 4.28.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/826)
- [Bump Selenium.WebDriver from 4.27.0 to 4.28.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/825)
- [Bump Selenium.WebDriver from 4.27.0 to 4.28.0 in /net](https://github.com/javiertuya/selema/pull/824)
- [Bump the mstest group across 2 directories with 2 updates](https://github.com/javiertuya/selema/pull/823)
- [Bump mikepenz/action-junit-report from 5.2.0 to 5.3.0](https://github.com/javiertuya/selema/pull/822)
- [Bump actions/upload-artifact from 4.5.0 to 4.6.0](https://github.com/javiertuya/selema/pull/821)
- [Bump actions/setup-dotnet from 4.2.0 to 4.3.0](https://github.com/javiertuya/selema/pull/820)