### PR TITLE
Combined dependency updates (2025-03-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
       #    skip_publishing: ${{ github.actor != 'javiertuya' }} #avoids failure on dependabot or other user PRs
       - name: Generate report checks1
         if: always()
-        uses: mikepenz/action-junit-report@v5.3.0
+        uses: mikepenz/action-junit-report@v5.4.0
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -70,7 +70,7 @@
 		<dependency>
 			<groupId>io.github.bonigarcia</groupId>
 			<artifactId>webdrivermanager</artifactId>
-			<version>5.9.2</version>
+			<version>5.9.3</version>
 		</dependency>
 
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -27,7 +27,7 @@
 		
 		<surefire.version>3.5.2</surefire.version>
 		
-		<slf4j.version>2.0.16</slf4j.version>
+		<slf4j.version>2.0.17</slf4j.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -108,7 +108,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.13.0</version>
+				<version>3.14.0</version>
 				<configuration>
 					<source>11</source>
 					<target>11</target>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 
-		<junit-jupiter.version>5.11.4</junit-jupiter.version>
+		<junit-jupiter.version>5.12.0</junit-jupiter.version>
 
 		<junit.version>4.13.2</junit.version>
 		

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.28.1</version>
+			<version>4.29.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -52,7 +52,7 @@
 
     <PackageReference Include="HtmlAgilityPack" Version="1.11.72" />
 
-    <PackageReference Include="NLog" Version="5.3.4" />
+    <PackageReference Include="NLog" Version="5.4.0" />
 
     <PackageReference Include="NUnit" Version="3.14.0" />
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -46,7 +46,7 @@
     <!-- required only for selenium 3
     <PackageReference Include="Microsoft.Edge.SeleniumTools" Version="3.141.2" />
     -->
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -62,7 +62,7 @@
 
     <PackageReference Include="WebDriverManager" Version="2.17.5" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.28.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.29.0" />
   </ItemGroup>
 
 </Project>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -50,7 +50,7 @@
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.72" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.74" />
 
     <PackageReference Include="NLog" Version="5.3.4" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -16,7 +16,7 @@
 
     <PackageReference Include="NUnit" Version="4.1.0" />
 
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 
     <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
 
     <PackageReference Include="NUnit" Version="4.1.0" />
 

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.28.1</version>
+			<version>4.29.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.11.4</version>
+			<version>5.12.0</version>
 		</dependency>
 		<dependency>
 		   <groupId>io.github.artsok</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.28.1</version>
+			<version>4.29.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.28.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.29.0" />
     
     <PackageReference Include="Selema" Version="3.2.3" />
   </ItemGroup>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
 

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.28.0" />
     

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.14.0" />
 
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.28.0" />
 

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.28.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.29.0" />
 
     <PackageReference Include="Selema" Version="3.2.3" />
   </ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.junit.jupiter:junit-jupiter-engine from 5.11.4 to 5.12.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/853)
- [Bump org.seleniumhq.selenium:selenium-java from 4.28.1 to 4.29.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/852)
- [Bump org.seleniumhq.selenium:selenium-java from 4.28.1 to 4.29.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/851)
- [Bump io.github.bonigarcia:webdrivermanager from 5.9.2 to 5.9.3 in /java](https://github.com/javiertuya/selema/pull/850)
- [Bump slf4j.version from 2.0.16 to 2.0.17 in /java](https://github.com/javiertuya/selema/pull/849)
- [Bump org.apache.maven.plugins:maven-compiler-plugin from 3.13.0 to 3.14.0 in /java](https://github.com/javiertuya/selema/pull/848)
- [Bump junit-jupiter.version from 5.11.4 to 5.12.0 in /java](https://github.com/javiertuya/selema/pull/847)
- [Bump org.seleniumhq.selenium:selenium-java from 4.28.1 to 4.29.0 in /java](https://github.com/javiertuya/selema/pull/846)
- [Bump Microsoft.NET.Test.Sdk from 17.12.0 to 17.13.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/845)
- [Bump NUnit3TestAdapter from 4.6.0 to 5.0.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/844)
- [Bump Selenium.WebDriver from 4.28.0 to 4.29.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/843)
- [Bump Microsoft.NET.Test.Sdk from 17.12.0 to 17.13.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/842)
- [Bump Selenium.WebDriver from 4.28.0 to 4.29.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/841)
- [Bump NLog from 5.3.4 to 5.4.0 in /net](https://github.com/javiertuya/selema/pull/840)
- [Bump NUnit3TestAdapter from 4.6.0 to 5.0.0 in /net](https://github.com/javiertuya/selema/pull/839)
- [Bump Selenium.WebDriver from 4.28.0 to 4.29.0 in /net](https://github.com/javiertuya/selema/pull/838)
- [Bump HtmlAgilityPack from 1.11.72 to 1.11.74 in /net](https://github.com/javiertuya/selema/pull/837)
- [Bump Microsoft.NET.Test.Sdk from 17.12.0 to 17.13.0 in /net](https://github.com/javiertuya/selema/pull/836)
- [Bump the mstest group across 2 directories with 2 updates](https://github.com/javiertuya/selema/pull/835)
- [Bump mikepenz/action-junit-report from 5.3.0 to 5.4.0](https://github.com/javiertuya/selema/pull/834)