### PR TITLE
Combined dependency updates (2025-05-03)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,7 +164,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: javiertuya/sonarqube-action@v1.4.1
+      - uses: javiertuya/sonarqube-action@v1.4.2
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 
-		<junit-jupiter.version>5.12.1</junit-jupiter.version>
+		<junit-jupiter.version>5.12.2</junit-jupiter.version>
 
 		<junit.version>4.13.2</junit.version>
 		

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.30.0</version>
+			<version>4.31.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -99,7 +99,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.18.0</version>
+			<version>2.19.0</version>
 		</dependency>
 	</dependencies>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -70,7 +70,7 @@
 		<dependency>
 			<groupId>io.github.bonigarcia</groupId>
 			<artifactId>webdrivermanager</artifactId>
-			<version>6.0.0</version>
+			<version>6.1.0</version>
 		</dependency>
 
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -136,7 +136,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.12</version>
+				<version>0.8.13</version>
 				<executions>
 					<execution>
 						<id>pre-unit-test</id>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -50,7 +50,7 @@
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 
-    <PackageReference Include="HtmlAgilityPack" Version="1.12.0" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.1" />
 
     <PackageReference Include="NLog" Version="5.4.0" />
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -62,7 +62,7 @@
 
     <PackageReference Include="WebDriverManager" Version="2.17.5" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.30.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.31.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.30.0</version>
+			<version>4.31.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.12.1</version>
+			<version>5.12.2</version>
 		</dependency>
 		<dependency>
 		   <groupId>io.github.artsok</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.30.0</version>
+			<version>4.31.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.30.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.31.0" />
     
     <PackageReference Include="Selema" Version="3.2.3" />
   </ItemGroup>

--- a/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
+++ b/samples/samples-selema-nunit3/samples-selema-nunit3/samples-selema-nunit3.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.30.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.31.0" />
 
     <PackageReference Include="Selema" Version="3.2.3" />
   </ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump Selenium.WebDriver from 4.30.0 to 4.31.0 in /samples/samples-selema-nunit3](https://github.com/javiertuya/selema/pull/887)
- [Bump Selenium.WebDriver from 4.30.0 to 4.31.0 in /samples/samples-selema-mstest2](https://github.com/javiertuya/selema/pull/886)
- [Bump Selenium.WebDriver from 4.30.0 to 4.31.0 in /net](https://github.com/javiertuya/selema/pull/885)
- [Bump HtmlAgilityPack from 1.12.0 to 1.12.1 in /net](https://github.com/javiertuya/selema/pull/884)
- [Bump javiertuya/sonarqube-action from 1.4.1 to 1.4.2](https://github.com/javiertuya/selema/pull/883)
- [Bump org.seleniumhq.selenium:selenium-java from 4.30.0 to 4.31.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/882)
- [Bump org.junit.jupiter:junit-jupiter-engine from 5.12.1 to 5.12.2 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/881)
- [Bump org.seleniumhq.selenium:selenium-java from 4.30.0 to 4.31.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/880)
- [Bump org.jacoco:jacoco-maven-plugin from 0.8.12 to 0.8.13 in /java](https://github.com/javiertuya/selema/pull/879)
- [Bump io.github.bonigarcia:webdrivermanager from 6.0.0 to 6.1.0 in /java](https://github.com/javiertuya/selema/pull/878)
- [Bump org.seleniumhq.selenium:selenium-java from 4.30.0 to 4.31.0 in /java](https://github.com/javiertuya/selema/pull/877)
- [Bump commons-io:commons-io from 2.18.0 to 2.19.0 in /java](https://github.com/javiertuya/selema/pull/876)
- [Bump junit-jupiter.version from 5.12.1 to 5.12.2 in /java](https://github.com/javiertuya/selema/pull/875)