### PR TITLE
Combined dependency updates (2025-06-07)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
       
       - name: Generate report checks
         if: always()
-        uses: mikepenz/action-junit-report@v5.5.1
+        uses: mikepenz/action-junit-report@v5.6.0
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.31.0</version>
+			<version>4.33.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 
-		<junit-jupiter.version>5.12.2</junit-jupiter.version>
+		<junit-jupiter.version>5.13.0</junit-jupiter.version>
 
 		<junit.version>4.13.2</junit.version>
 		

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.4.0</version>
+			<version>3.4.1</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.31.0</version>
+			<version>4.33.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.31.0</version>
+			<version>4.33.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.12.2</version>
+			<version>5.13.0</version>
 		</dependency>
 		<dependency>
 		   <groupId>io.github.artsok</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.4.0</version>
+			<version>3.4.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump mikepenz/action-junit-report from 5.5.1 to 5.6.0](https://github.com/javiertuya/selema/pull/896)
- [Bump io.github.javiertuya:selema from 3.4.0 to 3.4.1 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/895)
- [Bump org.junit.jupiter:junit-jupiter-engine from 5.12.2 to 5.13.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/894)
- [Bump org.seleniumhq.selenium:selenium-java from 4.31.0 to 4.33.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/893)
- [Bump io.github.javiertuya:selema from 3.4.0 to 3.4.1 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/892)
- [Bump org.seleniumhq.selenium:selenium-java from 4.31.0 to 4.33.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/891)
- [Bump junit-jupiter.version from 5.12.2 to 5.13.0 in /java](https://github.com/javiertuya/selema/pull/890)
- [Bump org.seleniumhq.selenium:selenium-java from 4.31.0 to 4.33.0 in /java](https://github.com/javiertuya/selema/pull/889)