### PR TITLE
Combined dependency updates (2025-07-01)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
       
       - name: Generate report checks
         if: always()
-        uses: mikepenz/action-junit-report@v5.6.0
+        uses: mikepenz/action-junit-report@v5.6.1
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.33.0</version>
+			<version>4.34.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 
-		<junit-jupiter.version>5.13.0</junit-jupiter.version>
+		<junit-jupiter.version>5.13.2</junit-jupiter.version>
 
 		<junit.version>4.13.2</junit.version>
 		

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -265,7 +265,7 @@
 					<plugin>
 						<groupId>org.sonatype.central</groupId>
 						<artifactId>central-publishing-maven-plugin</artifactId>
-						<version>0.7.0</version>
+						<version>0.8.0</version>
 						<extensions>true</extensions>
 						<configuration>
 							<publishingServerId>central</publishingServerId>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -46,7 +46,7 @@
     <!-- required only for selenium 3
     <PackageReference Include="Microsoft.Edge.SeleniumTools" Version="3.141.2" />
     -->
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
 
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -14,9 +14,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
 
     <PackageReference Include="NUnit" Version="4.1.0" />
 

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.33.0</version>
+			<version>4.34.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.33.0</version>
+			<version>4.34.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.13.0</version>
+			<version>5.13.2</version>
 		</dependency>
 		<dependency>
 		   <groupId>io.github.artsok</groupId>

--- a/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
+++ b/samples/samples-selema-mstest2/samples-selema-mstest2/samples-selema-mstest2.csproj
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.31.0" />
     


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.seleniumhq.selenium:selenium-java from 4.33.0 to 4.34.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/905)
- [Bump mikepenz/action-junit-report from 5.6.0 to 5.6.1](https://github.com/javiertuya/selema/pull/904)
- [Bump the mstest group with 2 updates](https://github.com/javiertuya/selema/pull/903)
- [Bump org.seleniumhq.selenium:selenium-java from 4.33.0 to 4.34.0 in /java](https://github.com/javiertuya/selema/pull/902)
- [Bump org.sonatype.central:central-publishing-maven-plugin from 0.7.0 to 0.8.0 in /java](https://github.com/javiertuya/selema/pull/901)
- [Bump org.seleniumhq.selenium:selenium-java from 4.33.0 to 4.34.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/900)
- [Bump org.junit.jupiter:junit-jupiter-engine from 5.13.0 to 5.13.2 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/899)
- [Bump junit-jupiter.version from 5.13.0 to 5.13.2 in /java](https://github.com/javiertuya/selema/pull/898)