### PR TITLE
Combined dependency updates (2025-08-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,7 +164,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: javiertuya/sonarqube-action@v1.4.2
+      - uses: javiertuya/sonarqube-action@v1.4.3
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
       
       - name: Generate report checks
         if: always()
-        uses: mikepenz/action-junit-report@v5.6.1
+        uses: mikepenz/action-junit-report@v5.6.2
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 
-		<junit-jupiter.version>5.13.2</junit-jupiter.version>
+		<junit-jupiter.version>5.13.4</junit-jupiter.version>
 
 		<junit.version>4.13.2</junit.version>
 		

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -276,7 +276,7 @@
                     <plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.2.7</version>
+						<version>3.2.8</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -70,7 +70,7 @@
 		<dependency>
 			<groupId>io.github.bonigarcia</groupId>
 			<artifactId>webdrivermanager</artifactId>
-			<version>6.1.0</version>
+			<version>6.2.0</version>
 		</dependency>
 
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -99,7 +99,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.19.0</version>
+			<version>2.20.0</version>
 		</dependency>
 	</dependencies>
 

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.13.2</version>
+			<version>5.13.4</version>
 		</dependency>
 		<dependency>
 		   <groupId>io.github.artsok</groupId>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.junit.jupiter:junit-jupiter-engine from 5.13.2 to 5.13.4 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/913)
- [Bump io.github.bonigarcia:webdrivermanager from 6.1.0 to 6.2.0 in /java](https://github.com/javiertuya/selema/pull/912)
- [Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.7 to 3.2.8 in /java](https://github.com/javiertuya/selema/pull/911)
- [Bump junit-jupiter.version from 5.13.2 to 5.13.4 in /java](https://github.com/javiertuya/selema/pull/910)
- [Bump commons-io:commons-io from 2.19.0 to 2.20.0 in /java](https://github.com/javiertuya/selema/pull/909)
- [Bump mikepenz/action-junit-report from 5.6.1 to 5.6.2](https://github.com/javiertuya/selema/pull/908)
- [Bump javiertuya/sonarqube-action from 1.4.2 to 1.4.3](https://github.com/javiertuya/selema/pull/907)