### PR TITLE
Combined dependency updates (2025-10-25)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,7 +190,7 @@ jobs:
       
       - name: Generate report checks
         if: always()
-        uses: mikepenz/action-junit-report@v5.6.2
+        uses: mikepenz/action-junit-report@v6.0.0
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -198,7 +198,7 @@ jobs:
 
       - if: always()
         name: Publish test report files
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v5.0.0
         with:
           name: "test-report-${{ matrix.platform }}-${{ matrix.mode }}-files"
           path: |
@@ -208,7 +208,7 @@ jobs:
             java/reports/selema/**/*
       - name: JAVA - Reports for Sonar
         if: ${{ always() && matrix.platform=='java' }}
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v5.0.0
         with:
           name: "sonar-${{ matrix.platform }}-${{ matrix.mode }}"
           path: |

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -179,7 +179,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.2.0</version>
 				<executions>
 					<!-- Reports de test (ut) estilo junit-->
 					<execution>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 
-		<junit-jupiter.version>5.13.4</junit-jupiter.version>
+		<junit-jupiter.version>5.14.0</junit-jupiter.version>
 
 		<junit.version>4.13.2</junit.version>
 		

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -136,7 +136,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.13</version>
+				<version>0.8.14</version>
 				<executions>
 					<execution>
 						<id>pre-unit-test</id>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -49,7 +49,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.7.0" >
+    <PackageReference Include="Selenium.WebDriver" Version="4.37.0" >
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
 
     <PackageReference Include="MSTest.TestFramework" Version="3.11.0" />
 

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.35.0</version>
+			<version>4.37.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.35.0</version>
+			<version>4.37.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.13.4</version>
+			<version>5.14.0</version>
 		</dependency>
 		<dependency>
 		   <groupId>io.github.artsok</groupId>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump Selenium.WebDriver from 4.7.0 to 4.37.0](https://github.com/javiertuya/selema/pull/945)
- [Bump org.junit.jupiter:junit-jupiter-engine from 5.13.4 to 5.14.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/942)
- [Bump org.seleniumhq.selenium:selenium-java from 4.35.0 to 4.37.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/940)
- [Bump Microsoft.NET.Test.Sdk from 17.14.1 to 18.0.0](https://github.com/javiertuya/selema/pull/941)
- [Bump org.seleniumhq.selenium:selenium-java from 4.35.0 to 4.37.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/939)
- [Bump org.apache.maven.plugins:maven-antrun-plugin from 3.1.0 to 3.2.0 in /java](https://github.com/javiertuya/selema/pull/938)
- [Bump org.jacoco:jacoco-maven-plugin from 0.8.13 to 0.8.14 in /java](https://github.com/javiertuya/selema/pull/937)
- [Bump junit-jupiter.version from 5.13.4 to 5.14.0 in /java](https://github.com/javiertuya/selema/pull/936)
- [Bump actions/upload-artifact from 4.6.2 to 5.0.0](https://github.com/javiertuya/selema/pull/935)
- [Bump mikepenz/action-junit-report from 5.6.2 to 6.0.0](https://github.com/javiertuya/selema/pull/934)