### PR TITLE
Combined dependency updates (2025-10-25)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.37.0</version>
+			<version>4.38.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -41,7 +41,7 @@
     The client must declare the chosen packages and the versions for each framework.
     Private assets are kept to lower versions to avoid deprecation warnings/errors in the clients
     -->
-    <PackageReference Include="MSTest.TestFramework" Version="4.0.0" >
+    <PackageReference Include="MSTest.TestFramework" Version="4.0.1" >
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
 

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.37.0</version>
+			<version>4.38.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.37.0</version>
+			<version>4.38.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
+++ b/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="4.0.1" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.37.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.38.0" />
 
     <PackageReference Include="Selema" Version="4.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump Selenium.WebDriver from 4.37.0 to 4.38.0](https://github.com/javiertuya/selema/pull/963)
- [Bump MSTest.TestFramework from 4.0.0 to 4.0.1](https://github.com/javiertuya/selema/pull/956)
- [Bump org.seleniumhq.selenium:selenium-java from 4.37.0 to 4.38.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/949)
- [Bump org.seleniumhq.selenium:selenium-java from 4.37.0 to 4.38.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/948)
- [Bump org.seleniumhq.selenium:selenium-java from 4.37.0 to 4.38.0 in /java](https://github.com/javiertuya/selema/pull/947)