### PR TITLE
Combined dependency updates (2025-11-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,7 +190,7 @@ jobs:
       
       - name: Generate report checks
         if: always()
-        uses: mikepenz/action-junit-report@v6.0.0
+        uses: mikepenz/action-junit-report@v6.0.1
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 
-		<junit-jupiter.version>5.14.0</junit-jupiter.version>
+		<junit-jupiter.version>5.14.1</junit-jupiter.version>
 
 		<junit.version>4.13.2</junit.version>
 		

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -52,7 +52,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.37.0" >
+    <PackageReference Include="Selenium.WebDriver" Version="4.38.0" >
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -18,7 +18,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.37.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.38.0" />
 
   </ItemGroup>
 

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.14.0</version>
+			<version>5.14.1</version>
 		</dependency>
 		<dependency>
 		   <groupId>io.github.artsok</groupId>

--- a/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
+++ b/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.37.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.38.0" />
 
     <PackageReference Include="Selema" Version="4.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump Selenium.WebDriver from 4.37.0 to 4.38.0](https://github.com/javiertuya/selema/pull/968)
- [Bump Selenium.WebDriver from 4.37.0 to 4.38.0](https://github.com/javiertuya/selema/pull/972)
- [Bump mikepenz/action-junit-report from 6.0.0 to 6.0.1](https://github.com/javiertuya/selema/pull/970)
- [Bump org.junit.jupiter:junit-jupiter-engine from 5.14.0 to 5.14.1 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/967)
- [Bump junit-jupiter.version from 5.14.0 to 5.14.1 in /java](https://github.com/javiertuya/selema/pull/966)