### PR TITLE
Combined dependency updates (2026-01-03)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -208,7 +208,7 @@ jobs:
       
       - name: Generate report checks
         if: always()
-        uses: mikepenz/action-junit-report@v6.0.1
+        uses: mikepenz/action-junit-report@v6.1.0
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.version }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -216,7 +216,7 @@ jobs:
 
       - if: always()
         name: Publish test report files
-        uses: actions/upload-artifact@v5.0.0
+        uses: actions/upload-artifact@v6.0.0
         with:
           name: "test-report-${{ matrix.platform }}-${{ matrix.version }}-${{ matrix.mode }}-files"
           path: |
@@ -226,7 +226,7 @@ jobs:
             java/reports/selema/**/*
       - name: JAVA - Reports for Sonar
         if: ${{ always() && matrix.platform=='java' }}
-        uses: actions/upload-artifact@v5.0.0
+        uses: actions/upload-artifact@v6.0.0
         with:
           name: "sonar-${{ matrix.platform }}-${{ matrix.version }}-${{ matrix.mode }}"
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -256,7 +256,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: javiertuya/sonarqube-action@v1.4.3
+      - uses: javiertuya/sonarqube-action@v1.4.4
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -65,7 +65,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.38.0</version>
+			<version>4.39.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -60,7 +60,7 @@
     <PackageReference Include="NUnit" Version="3.14.0" >
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Selenium.WebDriver" Version="4.38.0" >
+    <PackageReference Include="Selenium.WebDriver" Version="4.39.0" >
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -16,7 +16,7 @@
 
     <PackageReference Include="NUnit" Version="4.4.0" />
 
-    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.38.0" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -18,7 +18,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.38.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.39.0" />
 
   </ItemGroup>
 

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>4.0.1</version>
+			<version>4.0.2</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.38.0</version>
+			<version>4.39.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.38.0</version>
+			<version>4.39.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>4.0.1</version>
+			<version>4.0.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
+++ b/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.38.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.39.0" />
 
     <PackageReference Include="Selema" Version="4.0.1" />
   </ItemGroup>

--- a/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
+++ b/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
@@ -16,7 +16,7 @@
 
     <PackageReference Include="Selenium.WebDriver" Version="4.38.0" />
 
-    <PackageReference Include="Selema" Version="4.0.1" />
+    <PackageReference Include="Selema" Version="4.0.2" />
   </ItemGroup>
 
 </Project>

--- a/video-controller/app/package-lock.json
+++ b/video-controller/app/package-lock.json
@@ -574,9 +574,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump qs from 6.14.0 to 6.14.1 in /video-controller/app](https://github.com/javiertuya/selema/pull/1004)
- [Bump Selenium.WebDriver from 4.38.0 to 4.39.0](https://github.com/javiertuya/selema/pull/1000)
- [Bump Selenium.WebDriver from 4.38.0 to 4.39.0](https://github.com/javiertuya/selema/pull/1003)
- [Bump NUnit3TestAdapter from 5.2.0 to 6.0.1](https://github.com/javiertuya/selema/pull/1002)
- [Bump Selema from 4.0.1 to 4.0.2](https://github.com/javiertuya/selema/pull/999)
- [Bump io.github.javiertuya:selema from 4.0.1 to 4.0.2 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/998)
- [Bump org.seleniumhq.selenium:selenium-java from 4.38.0 to 4.39.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/997)
- [Bump io.github.javiertuya:selema from 4.0.1 to 4.0.2 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/996)
- [Bump org.seleniumhq.selenium:selenium-java from 4.38.0 to 4.39.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/995)
- [Bump org.seleniumhq.selenium:selenium-java from 4.38.0 to 4.39.0 in /java](https://github.com/javiertuya/selema/pull/994)
- [Bump actions/upload-artifact from 5.0.0 to 6.0.0](https://github.com/javiertuya/selema/pull/993)
- [Bump mikepenz/action-junit-report from 6.0.1 to 6.1.0](https://github.com/javiertuya/selema/pull/992)
- [Bump javiertuya/sonarqube-action from 1.4.3 to 1.4.4](https://github.com/javiertuya/selema/pull/991)