### PR TITLE
Combined dependency updates (2026-01-03)

### DIFF
--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -54,7 +54,7 @@
     </PackageReference>
     -->
 
-    <PackageReference Include="MSTest.TestFramework" Version="4.0.1" >
+    <PackageReference Include="MSTest.TestFramework" Version="4.0.2" >
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NUnit" Version="3.14.0" >

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="4.0.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="4.0.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
 
     <PackageReference Include="NUnit" Version="4.4.0" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="4.0.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="4.0.1" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
 
     <PackageReference Include="MSTest.TestFramework" Version="4.0.1" />
 

--- a/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
+++ b/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.38.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.39.0" />
 
     <PackageReference Include="Selema" Version="4.0.0" />
   </ItemGroup>

--- a/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
+++ b/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
@@ -16,7 +16,7 @@
 
     <PackageReference Include="Selenium.WebDriver" Version="4.38.0" />
 
-    <PackageReference Include="Selema" Version="4.0.0" />
+    <PackageReference Include="Selema" Version="4.0.2" />
   </ItemGroup>
 
 </Project>

--- a/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
+++ b/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="4.4.0" />
 
-    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump Selenium.WebDriver from 4.38.0 to 4.39.0](https://github.com/javiertuya/selema/pull/1011)
- [Bump Selema from 4.0.0 to 4.0.2](https://github.com/javiertuya/selema/pull/1010)
- [Bump NUnit3TestAdapter from 5.2.0 to 6.0.1](https://github.com/javiertuya/selema/pull/1009)
- [Bump MSTest.TestFramework from 4.0.1 to 4.0.2](https://github.com/javiertuya/selema/pull/1008)
- [Bump MSTest.TestAdapter and MSTest.TestFramework](https://github.com/javiertuya/selema/pull/1007)
- [Bump Microsoft.NET.Test.Sdk from 18.0.0 to 18.0.1](https://github.com/javiertuya/selema/pull/1006)