### PR TITLE
Combined dependency updates (2026-02-02)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       packages: write 
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-dotnet@v5.0.1
+      - uses: actions/setup-dotnet@v5.1.0
         with:
             dotnet-version: '6.0.x'
       - name: Pack

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -37,7 +37,7 @@ jobs:
           java-version: '11'
           cache: 'maven'
       - if: ${{ matrix.platform=='net' }}
-        uses: actions/setup-dotnet@v5.0.1
+        uses: actions/setup-dotnet@v5.1.0
         with:
             dotnet-version: '8.0.x'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
           java-version: '11'
           cache: 'maven'
       - if: ${{ matrix.platform=='net' }}
-        uses: actions/setup-dotnet@v5.0.1
+        uses: actions/setup-dotnet@v5.1.0
         with:
             dotnet-version: '8.0.x'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -208,7 +208,7 @@ jobs:
       
       - name: Generate report checks
         if: always()
-        uses: mikepenz/action-junit-report@v6.1.0
+        uses: mikepenz/action-junit-report@v6.2.0
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.version }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -290,7 +290,7 @@
 					<plugin>
 						<groupId>org.sonatype.central</groupId>
 						<artifactId>central-publishing-maven-plugin</artifactId>
-						<version>0.9.0</version>
+						<version>0.10.0</version>
 						<extensions>true</extensions>
 						<configuration>
 							<publishingServerId>central</publishingServerId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -65,7 +65,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.39.0</version>
+			<version>4.40.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -60,7 +60,7 @@
     <PackageReference Include="NUnit" Version="3.14.0" >
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Selenium.WebDriver" Version="4.39.0" >
+    <PackageReference Include="Selenium.WebDriver" Version="4.40.0" >
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -16,7 +16,7 @@
 
     <PackageReference Include="NUnit" Version="4.4.0" />
 
-    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.39.0" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -18,7 +18,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.39.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.40.0" />
 
   </ItemGroup>
 

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.39.0</version>
+			<version>4.40.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.14.1</version>
+			<version>5.14.2</version>
 		</dependency>
 		<dependency>
 		   <groupId>io.github.artsok</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.39.0</version>
+			<version>4.40.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
+++ b/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.39.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.40.0" />
 
     <PackageReference Include="Selema" Version="4.0.2" />
   </ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump Selenium.WebDriver from 4.39.0 to 4.40.0](https://github.com/javiertuya/selema/pull/1021)
- [Bump Selenium.WebDriver from 4.39.0 to 4.40.0](https://github.com/javiertuya/selema/pull/1022)
- [Bump NUnit3TestAdapter from 6.0.1 to 6.1.0](https://github.com/javiertuya/selema/pull/1020)
- [Bump org.junit.jupiter:junit-jupiter-engine from 5.14.1 to 5.14.2 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/1019)
- [Bump org.seleniumhq.selenium:selenium-java from 4.39.0 to 4.40.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/1018)
- [Bump org.seleniumhq.selenium:selenium-java from 4.39.0 to 4.40.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/1017)
- [Bump org.sonatype.central:central-publishing-maven-plugin from 0.9.0 to 0.10.0 in /java](https://github.com/javiertuya/selema/pull/1016)
- [Bump org.seleniumhq.selenium:selenium-java from 4.39.0 to 4.40.0 in /java](https://github.com/javiertuya/selema/pull/1015)
- [Bump actions/setup-dotnet from 5.0.1 to 5.1.0](https://github.com/javiertuya/selema/pull/1014)
- [Bump mikepenz/action-junit-report from 6.1.0 to 6.2.0](https://github.com/javiertuya/selema/pull/1013)