### PR TITLE
Combined dependency updates (2026-02-27)

### DIFF
--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -54,7 +54,7 @@
     </PackageReference>
     -->
 
-    <PackageReference Include="MSTest.TestFramework" Version="4.0.2" >
+    <PackageReference Include="MSTest.TestFramework" Version="4.1.0" >
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NUnit" Version="3.14.0" >

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -60,7 +60,7 @@
     <PackageReference Include="NUnit" Version="3.14.0" >
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Selenium.WebDriver" Version="4.40.0" >
+    <PackageReference Include="Selenium.WebDriver" Version="4.41.0" >
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />
 
     <PackageReference Include="NUnit" Version="4.4.0" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -18,7 +18,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.40.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.41.0" />
 
   </ItemGroup>
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
 
     <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
 

--- a/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
+++ b/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.39.0" />
 

--- a/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
+++ b/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.39.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.41.0" />
 
     <PackageReference Include="Selema" Version="4.0.2" />
   </ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump Selenium.WebDriver from 4.40.0 to 4.41.0](https://github.com/javiertuya/selema/pull/1027)
- [Bump MSTest.TestFramework from 4.0.2 to 4.1.0](https://github.com/javiertuya/selema/pull/1026)
- [Bump Microsoft.NET.Test.Sdk from 18.0.1 to 18.3.0](https://github.com/javiertuya/selema/pull/1030)
- [Bump Selenium.WebDriver from 4.39.0 to 4.41.0](https://github.com/javiertuya/selema/pull/1029)
- [Bump MSTest.TestFramework from 4.0.2 to 4.1.0](https://github.com/javiertuya/selema/pull/1028)
- [Bump MSTest.TestAdapter and MSTest.TestFramework](https://github.com/javiertuya/selema/pull/1025)