### PR TITLE
Combined dependency updates (2026-03-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -218,7 +218,7 @@ jobs:
 
       - if: always()
         name: Publish test report files
-        uses: actions/upload-artifact@v6.0.0
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: "test-report-${{ matrix.platform }}-${{ matrix.version }}-${{ matrix.mode }}-files"
           path: |
@@ -229,7 +229,7 @@ jobs:
             java/reports/selema/**/*
       - name: JAVA - Reports for Sonar
         if: ${{ always() && matrix.platform=='java' }}
-        uses: actions/upload-artifact@v6.0.0
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: "sonar-${{ matrix.platform }}-${{ matrix.version }}-${{ matrix.mode }}"
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,7 +210,7 @@ jobs:
       
       - name: Generate report checks
         if: always()
-        uses: mikepenz/action-junit-report@v6.2.0
+        uses: mikepenz/action-junit-report@v6.3.0
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.version }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -288,7 +288,7 @@ jobs:
       run:
         working-directory: java
     steps:
-      - uses: javiertuya/branch-snapshots-action@v1.2.3
+      - uses: javiertuya/branch-snapshots-action@v2.0.0
         with: 
           token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: java

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -26,7 +26,7 @@
 
 		<junit.version>4.13.2</junit.version>
 		
-		<surefire.version>3.5.4</surefire.version>
+		<surefire.version>3.5.5</surefire.version>
 		
 		<slf4j.version>2.0.17</slf4j.version>
 	</properties>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -65,7 +65,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.40.0</version>
+			<version>4.41.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -109,7 +109,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.14.1</version>
+				<version>3.15.0</version>
 				<configuration>
 					<source>17</source>
 					<target>17</target>

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.40.0</version>
+			<version>4.41.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -47,7 +47,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.5.4</version>
+				<version>3.5.5</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.14.2</version>
+			<version>5.14.3</version>
 		</dependency>
 		<dependency>
 		   <groupId>io.github.artsok</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.40.0</version>
+			<version>4.41.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.apache.maven.plugins:maven-surefire-plugin from 3.5.4 to 3.5.5 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/1041)
- [Bump org.junit.jupiter:junit-jupiter-engine from 5.14.2 to 5.14.3 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/1040)
- [Bump org.seleniumhq.selenium:selenium-java from 4.40.0 to 4.41.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/1039)
- [Bump org.seleniumhq.selenium:selenium-java from 4.40.0 to 4.41.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/1038)
- [Bump org.apache.maven.plugins:maven-compiler-plugin from 3.14.1 to 3.15.0 in /java](https://github.com/javiertuya/selema/pull/1037)
- [Bump surefire.version from 3.5.4 to 3.5.5 in /java](https://github.com/javiertuya/selema/pull/1036)
- [Bump javiertuya/branch-snapshots-action from 1.2.3 to 2.0.0](https://github.com/javiertuya/selema/pull/1035)
- [Bump mikepenz/action-junit-report from 6.2.0 to 6.3.0](https://github.com/javiertuya/selema/pull/1034)
- [Bump org.seleniumhq.selenium:selenium-java from 4.40.0 to 4.41.0 in /java](https://github.com/javiertuya/selema/pull/1033)
- [Bump actions/upload-artifact from 6.0.0 to 7.0.0](https://github.com/javiertuya/selema/pull/1032)