### PR TITLE
Combined dependency updates (2026-04-05)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       #https://stackoverflow.com/questions/61096521/how-to-use-gpg-key-in-github-actions
       #It requires export the private key with the armor option: gpg --output private.pgm --armor --export-secret-key <email>
       - name: Import GPG Key 
-        uses: crazy-max/ghaction-import-gpg@v6.3.0
+        uses: crazy-max/ghaction-import-gpg@v7.0.0
         with:
           gpg_private_key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       packages: write 
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-dotnet@v5.1.0
+      - uses: actions/setup-dotnet@v5.2.0
         with:
             dotnet-version: '6.0.x'
       - name: Pack

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -37,7 +37,7 @@ jobs:
           java-version: '11'
           cache: 'maven'
       - if: ${{ matrix.platform=='net' }}
-        uses: actions/setup-dotnet@v5.1.0
+        uses: actions/setup-dotnet@v5.2.0
         with:
             dotnet-version: '8.0.x'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,7 +210,7 @@ jobs:
       
       - name: Generate report checks
         if: always()
-        uses: mikepenz/action-junit-report@v6.3.0
+        uses: mikepenz/action-junit-report@v6.4.0
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.version }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
           java-version: '11'
           cache: 'maven'
       - if: ${{ matrix.platform=='net' }}
-        uses: actions/setup-dotnet@v5.1.0
+        uses: actions/setup-dotnet@v5.2.0
         with:
             dotnet-version: '8.0.x'
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -76,7 +76,7 @@
 
     <PackageReference Include="VisualAssert" Version="2.6.1" />
 
-    <PackageReference Include="WebDriverManager" Version="2.17.6" />
+    <PackageReference Include="WebDriverManager" Version="2.17.7" />
 
   </ItemGroup>
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -16,7 +16,7 @@
 
     <PackageReference Include="NUnit" Version="4.5.0" />
 
-    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.41.0" />
 

--- a/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
+++ b/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="4.5.0" />
 
-    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
 

--- a/video-controller/app/package-lock.json
+++ b/video-controller/app/package-lock.json
@@ -551,9 +551,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump WebDriverManager from 2.17.6 to 2.17.7](https://github.com/javiertuya/selema/pull/1048)
- [Bump the nunit group with 1 update](https://github.com/javiertuya/selema/pull/1047)
- [Bump actions/setup-dotnet from 5.1.0 to 5.2.0](https://github.com/javiertuya/selema/pull/1046)
- [Bump crazy-max/ghaction-import-gpg from 6.3.0 to 7.0.0](https://github.com/javiertuya/selema/pull/1045)
- [Bump mikepenz/action-junit-report from 6.3.0 to 6.4.0](https://github.com/javiertuya/selema/pull/1044)
- [Bump path-to-regexp from 8.3.0 to 8.4.0 in /video-controller/app](https://github.com/javiertuya/selema/pull/1043)