### PR TITLE
Combined dependency updates (2026-05-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -258,7 +258,7 @@ jobs:
 
       - if: always()
         name: Publish test report files
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: "test-report-${{ matrix.platform }}-${{ matrix.version }}-${{ matrix.mode }}-files"
           path: |
@@ -269,7 +269,7 @@ jobs:
             java/reports/selema/**/*
       - name: JAVA - Reports for Sonar
         if: ${{ always() && matrix.platform=='java' }}
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: "sonar-${{ matrix.platform }}-${{ matrix.version }}-${{ matrix.mode }}"
           path: |

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -100,7 +100,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.21.0</version>
+			<version>2.22.0</version>
 		</dependency>
 	</dependencies>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -65,7 +65,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.41.0</version>
+			<version>4.43.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -71,7 +71,7 @@
 		<dependency>
 			<groupId>io.github.bonigarcia</groupId>
 			<artifactId>webdrivermanager</artifactId>
-			<version>6.3.3</version>
+			<version>6.3.4</version>
 		</dependency>
 
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -206,7 +206,7 @@
 					<dependency>
 						<groupId>org.apache.ant</groupId>
 						<artifactId>ant-junit</artifactId>
-						<version>1.10.15</version>
+						<version>1.10.17</version>
 					</dependency>
 					<dependency>
 						<groupId>org.apache.ant</groupId>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -60,7 +60,7 @@
     <PackageReference Include="NUnit" Version="3.14.0" >
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Selenium.WebDriver" Version="4.41.0" >
+    <PackageReference Include="Selenium.WebDriver" Version="4.43.0" >
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -54,7 +54,7 @@
     </PackageReference>
     -->
 
-    <PackageReference Include="MSTest.TestFramework" Version="4.1.0" >
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.2" >
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NUnit" Version="3.14.0" >

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -18,7 +18,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.41.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.43.0" />
 
   </ItemGroup>
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 
     <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.2" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.2" />
 
     <PackageReference Include="NUnit" Version="4.5.0" />
 

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.41.0</version>
+			<version>4.43.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.41.0</version>
+			<version>4.43.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.14.3</version>
+			<version>5.14.4</version>
 		</dependency>
 		<dependency>
 		   <groupId>io.github.artsok</groupId>

--- a/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
+++ b/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />
 

--- a/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
+++ b/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.41.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.43.0" />
 
     <PackageReference Include="Selema" Version="4.0.2" />
   </ItemGroup>

--- a/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
+++ b/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.2" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.2" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.41.0" />
 

--- a/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
+++ b/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.41.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.43.0" />
 
     <PackageReference Include="Selema" Version="4.0.2" />
   </ItemGroup>

--- a/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
+++ b/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.41.0" />
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.seleniumhq.selenium:selenium-java from 4.41.0 to 4.43.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/1055)
- [Bump org.seleniumhq.selenium:selenium-java from 4.41.0 to 4.43.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/1056)
- [Bump org.junit.jupiter:junit-jupiter-engine from 5.14.3 to 5.14.4 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/1057)
- [Bump actions/upload-artifact from 7.0.0 to 7.0.1](https://github.com/javiertuya/selema/pull/1050)
- [Bump commons-io:commons-io from 2.21.0 to 2.22.0 in /java](https://github.com/javiertuya/selema/pull/1051)
- [Bump org.apache.ant:ant-junit from 1.10.15 to 1.10.17 in /java](https://github.com/javiertuya/selema/pull/1052)
- [Bump io.github.bonigarcia:webdrivermanager from 6.3.3 to 6.3.4 in /java](https://github.com/javiertuya/selema/pull/1053)
- [Bump org.seleniumhq.selenium:selenium-java from 4.41.0 to 4.43.0 in /java](https://github.com/javiertuya/selema/pull/1054)
- [Bump MSTest.TestAdapter and MSTest.TestFramework](https://github.com/javiertuya/selema/pull/1059)
- [Bump Selenium.WebDriver from 4.41.0 to 4.43.0](https://github.com/javiertuya/selema/pull/1060)
- [Bump Microsoft.NET.Test.Sdk from 18.3.0 to 18.5.1](https://github.com/javiertuya/selema/pull/1058)