### PR TITLE
Combined dependency updates (2026-06-02)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       packages: write 
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-dotnet@v5.2.0
+      - uses: actions/setup-dotnet@v5.3.0
         with:
             dotnet-version: '10.0.x'
       - name: Pack

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           cache: 'maven'
       - if: ${{ matrix.platform=='net' }}
         uses: actions/setup-dotnet@v5.2.0

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -37,7 +37,7 @@ jobs:
           java-version: '11'
           cache: 'maven'
       - if: ${{ matrix.platform=='net' }}
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5.3.0
         with:
             dotnet-version: '10.0.x'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
           java-version: '11'
           cache: 'maven'
       - if: ${{ matrix.platform=='net' }}
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5.3.0
         with:
             dotnet-version: '10.0.x'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -224,7 +224,7 @@ jobs:
       
       - name: Generate report checks
         if: always()
-        uses: mikepenz/action-junit-report@v6.4.0
+        uses: mikepenz/action-junit-report@v6.4.1
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.version }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -65,7 +65,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.43.0</version>
+			<version>4.44.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -26,7 +26,7 @@
 
 		<junit.version>4.13.2</junit.version>
 		
-		<surefire.version>3.5.5</surefire.version>
+		<surefire.version>3.5.6</surefire.version>
 		
 		<slf4j.version>2.0.17</slf4j.version>
 	</properties>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -28,7 +28,7 @@
 		
 		<surefire.version>3.5.5</surefire.version>
 		
-		<slf4j.version>2.0.17</slf4j.version>
+		<slf4j.version>2.0.18</slf4j.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.target>17</maven.compiler.target>
 
 		<!-- by default uses junit6 on jdk17, to check junit5 uses a profile activated when running jdk11 -->
-		<junit-jupiter.version>6.0.0</junit-jupiter.version>
+		<junit-jupiter.version>6.1.0</junit-jupiter.version>
 
 		<junit.version>4.13.2</junit.version>
 		

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -56,7 +56,7 @@
     </PackageReference>
     -->
 
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.2" >
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" >
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NUnit" Version="3.14.0" >

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
 
     <PackageReference Include="NUnit" Version="4.5.0" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 
     <PackageReference Include="MSTest.TestFramework" Version="4.2.2" />
 

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>4.0.2</version>
+			<version>4.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.43.0</version>
+			<version>4.44.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 		    <groupId>org.slf4j</groupId>
 		    <artifactId>slf4j-log4j12</artifactId>
-		    <version>1.7.33</version>
+		    <version>2.0.18</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.43.0</version>
+			<version>4.44.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -47,7 +47,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.5.5</version>
+				<version>3.5.6</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -10,8 +10,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
+		<maven.compiler.release>17</maven.compiler.release>
 	</properties>
 
 	<dependencies>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.14.4</version>
+			<version>6.1.0</version>
 		</dependency>
 		<dependency>
 		   <groupId>io.github.artsok</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>4.0.2</version>
+			<version>4.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -38,7 +38,7 @@
 		<dependency>
 		    <groupId>org.slf4j</groupId>
 		    <artifactId>slf4j-log4j12</artifactId>
-		    <version>1.7.33</version>
+		    <version>2.0.18</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
+++ b/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="4.2.2" />
 

--- a/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
+++ b/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="4.2.2" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.43.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.44.0" />
 
     <PackageReference Include="Selema" Version="4.0.2" />
   </ItemGroup>

--- a/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
+++ b/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
@@ -16,7 +16,7 @@
 
     <PackageReference Include="Selenium.WebDriver" Version="4.43.0" />
 
-    <PackageReference Include="Selema" Version="4.0.2" />
+    <PackageReference Include="Selema" Version="4.1.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
+++ b/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.43.0" />
 

--- a/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
+++ b/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="4.2.2" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.43.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.44.0" />
 
     <PackageReference Include="Selema" Version="4.1.0" />
   </ItemGroup>

--- a/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
+++ b/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
@@ -16,7 +16,7 @@
 
     <PackageReference Include="Selenium.WebDriver" Version="4.44.0" />
 
-    <PackageReference Include="Selema" Version="4.0.2" />
+    <PackageReference Include="Selema" Version="4.1.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
+++ b/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.43.0" />
 

--- a/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
+++ b/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.43.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.44.0" />
 
     <PackageReference Include="Selema" Version="4.0.2" />
   </ItemGroup>

--- a/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
+++ b/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
@@ -16,7 +16,7 @@
 
     <PackageReference Include="Selenium.WebDriver" Version="4.44.0" />
 
-    <PackageReference Include="Selema" Version="4.0.2" />
+    <PackageReference Include="Selema" Version="4.1.0" />
   </ItemGroup>
 
 </Project>

--- a/video-controller/app/package-lock.json
+++ b/video-controller/app/package-lock.json
@@ -574,9 +574,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump the mstest group with 2 updates](https://github.com/javiertuya/selema/pull/1082)
- [Bump the net-test-sdk group with 1 update](https://github.com/javiertuya/selema/pull/1081)
- [Bump the selenium group with 1 update](https://github.com/javiertuya/selema/pull/1083)
- [Bump Selema from 4.0.2 to 4.1.0](https://github.com/javiertuya/selema/pull/1084)
- [Bump org.junit.jupiter:junit-jupiter-engine from 5.14.4 to 6.1.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/1076)
- [Bump mikepenz/action-junit-report from 6.4.0 to 6.4.1](https://github.com/javiertuya/selema/pull/1080)
- [Bump actions/setup-dotnet from 5.2.0 to 5.3.0](https://github.com/javiertuya/selema/pull/1079)
- [Bump org.seleniumhq.selenium:selenium-java from 4.43.0 to 4.44.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/1078)
- [Bump org.apache.maven.plugins:maven-surefire-plugin from 3.5.5 to 3.5.6 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/1077)
- [Bump io.github.javiertuya:selema from 4.0.2 to 4.1.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/1075)
- [Bump org.slf4j:slf4j-log4j12 from 1.7.33 to 2.0.18 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/1074)
- [Bump org.slf4j:slf4j-log4j12 from 1.7.33 to 2.0.18 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/1073)
- [Bump org.seleniumhq.selenium:selenium-java from 4.43.0 to 4.44.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/1072)
- [Bump io.github.javiertuya:selema from 4.0.2 to 4.1.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/1071)
- [Bump slf4j.version from 2.0.17 to 2.0.18 in /java](https://github.com/javiertuya/selema/pull/1070)
- [Bump surefire.version from 3.5.5 to 3.5.6 in /java](https://github.com/javiertuya/selema/pull/1069)
- [Bump org.seleniumhq.selenium:selenium-java from 4.43.0 to 4.44.0 in /java](https://github.com/javiertuya/selema/pull/1068)
- [Bump junit-jupiter.version from 6.0.0 to 6.1.0 in /java](https://github.com/javiertuya/selema/pull/1067)
- [Bump qs from 6.14.2 to 6.15.2 in /video-controller/app](https://github.com/javiertuya/selema/pull/1066)