### PR TITLE
Combined dependency updates (2026-07-04)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       packages: write 
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-dotnet@v5.3.0
+      - uses: actions/setup-dotnet@v5.4.0
         with:
             dotnet-version: '10.0.x'
       - name: Pack

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -37,7 +37,7 @@ jobs:
           java-version: '17'
           cache: 'maven'
       - if: ${{ matrix.platform=='net' }}
-        uses: actions/setup-dotnet@v5.3.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
             dotnet-version: '10.0.x'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -226,7 +226,7 @@ jobs:
       
       - name: Generate report checks
         if: always()
-        uses: mikepenz/action-junit-report@v6.4.1
+        uses: mikepenz/action-junit-report@v6.4.2
         with:
           check_name: "test-result-${{ matrix.platform }}-${{ matrix.version }}-${{ matrix.mode }}"
           report_paths: "**/${{ env.REPORT_FOLDER }}/surefire-reports/TEST-*.xml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
           java-version: '11'
           cache: 'maven'
       - if: ${{ matrix.platform=='net' }}
-        uses: actions/setup-dotnet@v5.3.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
             dotnet-version: '10.0.x'
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -137,7 +137,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.14</version>
+				<version>0.8.15</version>
 				<executions>
 					<execution>
 						<id>pre-unit-test</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.target>17</maven.compiler.target>
 
 		<!-- by default uses junit6 on jdk17, to check junit5 uses a profile activated when running jdk11 -->
-		<junit-jupiter.version>6.1.0</junit-jupiter.version>
+		<junit-jupiter.version>6.1.1</junit-jupiter.version>
 
 		<junit.version>4.13.2</junit.version>
 		

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -290,7 +290,7 @@
 					<plugin>
 						<groupId>org.sonatype.central</groupId>
 						<artifactId>central-publishing-maven-plugin</artifactId>
-						<version>0.10.0</version>
+						<version>0.11.0</version>
 						<extensions>true</extensions>
 						<configuration>
 							<publishingServerId>central</publishingServerId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -65,7 +65,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.44.0</version>
+			<version>4.45.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -62,7 +62,7 @@
     <PackageReference Include="NUnit" Version="3.14.0" >
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Selenium.WebDriver" Version="4.44.0" >
+    <PackageReference Include="Selenium.WebDriver" Version="4.45.0" >
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 
     <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -18,7 +18,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.44.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.45.0" />
 
   </ItemGroup>
 

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.44.0</version>
+			<version>4.45.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>6.1.0</version>
+			<version>6.1.1</version>
 		</dependency>
 		<dependency>
 		   <groupId>io.github.artsok</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.44.0</version>
+			<version>4.45.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
+++ b/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
 

--- a/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
+++ b/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.44.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.45.0" />
 
     <PackageReference Include="Selema" Version="4.1.0" />
   </ItemGroup>

--- a/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
+++ b/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.44.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.45.0" />
 
     <PackageReference Include="Selema" Version="4.1.0" />
   </ItemGroup>

--- a/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
+++ b/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.44.0" />
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.seleniumhq.selenium:selenium-java from 4.44.0 to 4.45.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/1094)
- [Bump org.junit.jupiter:junit-jupiter-engine from 6.1.0 to 6.1.1 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/1095)
- [Bump org.seleniumhq.selenium:selenium-java from 4.44.0 to 4.45.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/1093)
- [Bump org.sonatype.central:central-publishing-maven-plugin from 0.10.0 to 0.11.0 in /java](https://github.com/javiertuya/selema/pull/1091)
- [Bump org.seleniumhq.selenium:selenium-java from 4.44.0 to 4.45.0 in /java](https://github.com/javiertuya/selema/pull/1090)
- [Bump org.jacoco:jacoco-maven-plugin from 0.8.14 to 0.8.15 in /java](https://github.com/javiertuya/selema/pull/1092)
- [Bump junit-jupiter.version from 6.1.0 to 6.1.1 in /java](https://github.com/javiertuya/selema/pull/1089)
- [Bump mikepenz/action-junit-report from 6.4.1 to 6.4.2](https://github.com/javiertuya/selema/pull/1088)
- [Bump actions/setup-dotnet from 5.3.0 to 5.4.0](https://github.com/javiertuya/selema/pull/1087)
- [Bump Selenium.WebDriver from 4.44.0 to 4.45.0](https://github.com/javiertuya/selema/pull/1097)
- [Bump Microsoft.NET.Test.Sdk from 18.6.0 to 18.7.0](https://github.com/javiertuya/selema/pull/1096)

Does not include these updates because of merge conflicts:
- [Bump actions/checkout from 6 to 7](https://github.com/javiertuya/selema/pull/1086)