### PR TITLE
Update nuget publish to OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,9 +45,10 @@ jobs:
     defaults:
       run:
         working-directory: net
-    permissions: 
+    permissions:
       contents: read
-      packages: write 
+      packages: write
+      id-token: write # required for nuget.org trusted publishing (OIDC token issuance)
     steps:
       - uses: actions/checkout@v7
       - name: Set up .NET
@@ -63,7 +64,17 @@ jobs:
       #  env:
       #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Trusted Publishing: exchanges the GitHub OIDC token for a short-lived (1h) nuget.org API key.
+      # Requires a trusted publishing policy configured at nuget.org matching this repo and workflow file.
+      # NUGET_USER is the nuget.org account/profile name (NOT the email).
+      # https://learn.microsoft.com/nuget/nuget-org/trusted-publishing
+      - name: NuGet login (OIDC -> temporary API key)
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Push to nuget.org
-        run: dotnet nuget push Selema/nupkg/*.nupkg  --api-key ${{ secrets.NUGET_API_KEY }} --source "https://api.nuget.org/v3/index.json"
+        run: dotnet nuget push Selema/nupkg/*.nupkg  --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source "https://api.nuget.org/v3/index.json"
       #- name: Push to int.nugettest.org
       #  run: dotnet nuget push Selema/nupkg/*.nupkg  --api-key ${{ secrets.NUGETTEST_API_KEY }} --source "https://apiint.nugettest.org/v3/index.json"


### PR DESCRIPTION
This PR updates the NuGet release workflow to use nuget.org Trusted Publishing (OIDC): the release job now requests a short-lived API key through the NuGet/login action using GitHub's OIDC token instead of the long-lived NUGET_API_KEY secret. It requires a matching trusted publishing policy configured on nuget.org and a NUGET_USER secret. See https://learn.microsoft.com/nuget/nuget-org/trusted-publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)