### PR TITLE
Combined dependency updates (2026-07-11)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -65,7 +65,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.45.0</version>
+			<version>4.46.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -82,7 +82,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>visual-assert</artifactId>
-			<version>2.6.1</version>
+			<version>2.6.2</version>
 		</dependency>
 
 		<dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -77,7 +77,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>portable-java</artifactId>
-			<version>2.4.3</version>
+			<version>2.4.4</version>
 		</dependency>
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -78,7 +78,7 @@
 
     <PackageReference Include="PortableCs" Version="2.4.3" />
 
-    <PackageReference Include="VisualAssert" Version="2.6.1" />
+    <PackageReference Include="VisualAssert" Version="2.6.2" />
 
     <PackageReference Include="WebDriverManager" Version="2.17.7" />
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -56,7 +56,7 @@
     </PackageReference>
     -->
 
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" >
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.0" >
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NUnit" Version="3.14.0" >

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -62,7 +62,7 @@
     <PackageReference Include="NUnit" Version="3.14.0" >
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Selenium.WebDriver" Version="4.45.0" >
+    <PackageReference Include="Selenium.WebDriver" Version="4.46.0" >
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
 

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -76,7 +76,7 @@
     <PackageReference Include="NLog" Version="5.5.0" />
     -->
 
-    <PackageReference Include="PortableCs" Version="2.4.3" />
+    <PackageReference Include="PortableCs" Version="2.4.4" />
 
     <PackageReference Include="VisualAssert" Version="2.6.1" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -18,7 +18,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.45.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.46.0" />
 
   </ItemGroup>
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.0" />
 
     <PackageReference Include="NUnit" Version="4.5.0" />
 

--- a/samples/samples-selema-junit4/pom.xml
+++ b/samples/samples-selema-junit4/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.45.0</version>
+			<version>4.46.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.45.0</version>
+			<version>4.46.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>

--- a/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
+++ b/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.45.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.46.0" />
 
     <PackageReference Include="Selema" Version="4.1.0" />
   </ItemGroup>

--- a/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
+++ b/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.0" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.0" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.45.0" />
 

--- a/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
+++ b/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
@@ -14,7 +14,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 
-    <PackageReference Include="Selenium.WebDriver" Version="4.45.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.46.0" />
 
     <PackageReference Include="Selema" Version="4.1.0" />
   </ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump VisualAssert from 2.6.1 to 2.6.2](https://github.com/javiertuya/selema/pull/1108)
- [Bump PortableCs from 2.4.3 to 2.4.4](https://github.com/javiertuya/selema/pull/1107)
- [Bump the selenium group with 1 update](https://github.com/javiertuya/selema/pull/1106)
- [Bump the mstest group with 2 updates](https://github.com/javiertuya/selema/pull/1105)
- [Bump org.seleniumhq.selenium:selenium-java from 4.45.0 to 4.46.0 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/1104)
- [Bump org.seleniumhq.selenium:selenium-java from 4.45.0 to 4.46.0 in /samples/samples-selema-junit4](https://github.com/javiertuya/selema/pull/1103)
- [Bump io.github.javiertuya:visual-assert from 2.6.1 to 2.6.2 in /java](https://github.com/javiertuya/selema/pull/1102)
- [Bump org.seleniumhq.selenium:selenium-java from 4.45.0 to 4.46.0 in /java](https://github.com/javiertuya/selema/pull/1101)
- [Bump io.github.javiertuya:portable-java from 2.4.3 to 2.4.4 in /java](https://github.com/javiertuya/selema/pull/1100)