### PR TITLE
Update Node container image 22 -> 24 in video-controller

### DIFF
--- a/video-controller/app/Dockerfile
+++ b/video-controller/app/Dockerfile
@@ -1,5 +1,5 @@
-FROM node:22-alpine
-#FROM node:22.20-slim
+FROM node:24-alpine
+#FROM node:24-slim
 
 # Install docker-cli (Alpine)
 RUN apk add --no-cache docker-cli


### PR DESCRIPTION
Node.js 22 llega a end-of-life el **2027-04-30**. Se actualiza a **24** (LTS activa, soporte hasta 2028-04-30).

Cambio en `video-controller/app/Dockerfile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)