### PR TITLE
Combined dependency updates (2026-07-19)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Set up .NET
-        uses: actions/setup-dotnet@v5.4.0
+        uses: actions/setup-dotnet@v6.0.0
         with:
             dotnet-version: '10.0.x'
       - name: Pack

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -37,7 +37,7 @@ jobs:
           java-version: '17'
           cache: 'maven'
       - if: ${{ matrix.platform=='net' }}
-        uses: actions/setup-dotnet@v5.4.0
+        uses: actions/setup-dotnet@v6.0.0
         with:
             dotnet-version: '10.0.x'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
           java-version: '11'
           cache: 'maven'
       - if: ${{ matrix.platform=='net' }}
-        uses: actions/setup-dotnet@v5.4.0
+        uses: actions/setup-dotnet@v6.0.0
         with:
             dotnet-version: '10.0.x'
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.target>17</maven.compiler.target>
 
 		<!-- by default uses junit6 on jdk17, to check junit5 uses a profile activated when running jdk11 -->
-		<junit-jupiter.version>6.1.1</junit-jupiter.version>
+		<junit-jupiter.version>6.1.2</junit-jupiter.version>
 
 		<junit.version>4.13.2</junit.version>
 		

--- a/net/Selema/Selema.csproj
+++ b/net/Selema/Selema.csproj
@@ -56,7 +56,7 @@
     </PackageReference>
     -->
 
-    <PackageReference Include="MSTest.TestFramework" Version="4.3.0" >
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.2" >
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NUnit" Version="3.14.0" >

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="4.3.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.2" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="4.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.2" />
 
     <PackageReference Include="NUnit" Version="4.5.0" />
 

--- a/net/SelemaTest/SelemaTest.csproj
+++ b/net/SelemaTest/SelemaTest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 
     <PackageReference Include="MSTest.TestFramework" Version="4.3.0" />
 

--- a/samples/samples-selema-junit5/pom.xml
+++ b/samples/samples-selema-junit5/pom.xml
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>6.1.1</version>
+			<version>6.1.2</version>
 		</dependency>
 		<dependency>
 		   <groupId>io.github.artsok</groupId>

--- a/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
+++ b/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="4.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.2" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="4.3.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.2" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.46.0" />
 

--- a/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
+++ b/samples/samples-selema-mstest/samples-selema-mstest/samples-selema-mstest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="4.3.0" />
 

--- a/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
+++ b/samples/samples-selema-nunit/samples-selema-nunit/samples-selema-nunit.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 
     <PackageReference Include="Selenium.WebDriver" Version="4.46.0" />
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump the mstest group with 2 updates](https://github.com/javiertuya/selema/pull/1114)
- [Bump the net-test-sdk group with 1 update](https://github.com/javiertuya/selema/pull/1113)
- [Bump org.junit.jupiter:junit-jupiter-engine from 6.1.1 to 6.1.2 in /samples/samples-selema-junit5](https://github.com/javiertuya/selema/pull/1112)
- [Bump junit-jupiter.version from 6.1.1 to 6.1.2 in /java](https://github.com/javiertuya/selema/pull/1111)
- [Bump actions/setup-dotnet from 5.4.0 to 6.0.0](https://github.com/javiertuya/selema/pull/1110)